### PR TITLE
Update GoReleaser action version to "~> v2" for improved compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           # goreleaserのバージョン指定
-          version: latest
+          version: "~> v2"
           # .goreleaser.yml の 'builds' セクションを実行
           args: release --clean
           workdir: ./go


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration. The change specifies a version constraint for the `goreleaser/goreleaser-action` used in the release workflow, switching from always using the latest version to using any compatible v2.x version.