### PR TITLE
refactor(go): VMコマンドの責務境界を明確化

### DIFF
--- a/go/cmd/describe.go
+++ b/go/cmd/describe.go
@@ -42,7 +42,7 @@ Example:
 		}
 
 		// 依存性の注入
-		vmRepo := gcp.NewVMRepository(CnfPath, infraLog.DefaultLogger)
+		vmRepo := gcp.NewVMRepository(infraLog.DefaultLogger)
 		describeVMUseCase := usecase.NewDescribeVMUseCase(vmRepo)
 
 		// Describe the instance

--- a/go/cmd/describe.go
+++ b/go/cmd/describe.go
@@ -9,9 +9,9 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/haru-256/gcectl/internal/infrastructure/config"
 	"github.com/haru-256/gcectl/internal/infrastructure/gcp"
 	infraLog "github.com/haru-256/gcectl/internal/infrastructure/log"
+	"github.com/haru-256/gcectl/internal/interface/cli"
 	"github.com/haru-256/gcectl/internal/interface/presenter"
 	"github.com/haru-256/gcectl/internal/usecase"
 	"github.com/spf13/cobra"
@@ -35,29 +35,21 @@ Example:
 			os.Exit(1)
 		}
 
-		// parse config
-		cnf, err := config.ParseConfig(CnfPath)
+		vm, err := cli.ResolveVMByName(CnfPath, vmName)
 		if err != nil {
-			console.Error(fmt.Sprintf("Failed to parse config: %v\n", err))
-			os.Exit(1)
-		}
-		infraLog.DefaultLogger.Debug(fmt.Sprintf("Config: %+v", cnf))
-
-		// filter VM by name
-		vm := cnf.GetVMByName(vmName)
-		if vm == nil {
-			console.Error(fmt.Sprintf("VM %s not found", vmName))
+			console.Error(fmt.Sprintf("%v\n", err))
 			os.Exit(1)
 		}
 
 		// 依存性の注入
 		vmRepo := gcp.NewVMRepository(CnfPath, infraLog.DefaultLogger)
+		describeVMUseCase := usecase.NewDescribeVMUseCase(vmRepo)
 
 		// Describe the instance
 		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
 
-		vmDetail, uptimeStr, err := usecase.DescribeVM(ctx, vmRepo, vm.Project, vm.Zone, vm.Name)
+		vmDetail, uptimeStr, err := describeVMUseCase.Execute(ctx, vm.Project, vm.Zone, vm.Name)
 		if err != nil {
 			console.Error(fmt.Sprintf("Failed to get VM info: %v\n", err))
 			os.Exit(1)

--- a/go/cmd/list.go
+++ b/go/cmd/list.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/haru-256/gcectl/internal/infrastructure/gcp"
 	infraLog "github.com/haru-256/gcectl/internal/infrastructure/log"
+	"github.com/haru-256/gcectl/internal/interface/cli"
 	"github.com/haru-256/gcectl/internal/interface/presenter"
 	"github.com/haru-256/gcectl/internal/usecase"
 	"github.com/spf13/cobra"
@@ -22,15 +23,21 @@ Example:
   gcectl list`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// 依存性の注入
-		vmRepo := gcp.NewVMRepository(CnfPath, infraLog.DefaultLogger)
 		console := presenter.NewConsolePresenter()
+		cfg, err := cli.LoadConfig(CnfPath)
+		if err != nil {
+			console.Error(fmt.Sprintf("%v\n", err))
+			os.Exit(1)
+		}
+
+		vmRepo := gcp.NewVMRepository(CnfPath, infraLog.DefaultLogger)
 		listVMsUC := usecase.NewListVMsUseCase(vmRepo)
 
 		// List VMs
 		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
 
-		items, err := listVMsUC.Execute(ctx)
+		items, err := listVMsUC.Execute(ctx, cfg.VMs)
 		if err != nil {
 			console.Error(fmt.Sprintf("Failed to list VMs: %v\n", err))
 			os.Exit(1)

--- a/go/cmd/list.go
+++ b/go/cmd/list.go
@@ -30,7 +30,7 @@ Example:
 			os.Exit(1)
 		}
 
-		vmRepo := gcp.NewVMRepository(CnfPath, infraLog.DefaultLogger)
+		vmRepo := gcp.NewVMRepository(infraLog.DefaultLogger)
 		listVMsUC := usecase.NewListVMsUseCase(vmRepo)
 
 		// List VMs
@@ -38,11 +38,6 @@ Example:
 		defer stop()
 
 		items, err := listVMsUC.Execute(ctx, cfg.VMs)
-		if err != nil {
-			console.Error(fmt.Sprintf("Failed to list VMs: %v\n", err))
-			os.Exit(1)
-		}
-
 		infraLog.DefaultLogger.Debugf("Found %d VMs", len(items))
 
 		// Convert usecase items to presenter items
@@ -60,7 +55,13 @@ Example:
 		}
 
 		// Render VM list
-		console.RenderVMList(presenterItems)
+		if len(presenterItems) > 0 {
+			console.RenderVMList(presenterItems)
+		}
+		if err != nil {
+			console.Error(fmt.Sprintf("Failed to list some VMs: %v\n", err))
+			os.Exit(1)
+		}
 	},
 }
 

--- a/go/cmd/off.go
+++ b/go/cmd/off.go
@@ -8,10 +8,9 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/haru-256/gcectl/internal/domain/model"
-	"github.com/haru-256/gcectl/internal/infrastructure/config"
 	"github.com/haru-256/gcectl/internal/infrastructure/gcp"
 	infraLog "github.com/haru-256/gcectl/internal/infrastructure/log"
+	"github.com/haru-256/gcectl/internal/interface/cli"
 	"github.com/haru-256/gcectl/internal/interface/presenter"
 	"github.com/haru-256/gcectl/internal/usecase"
 	"github.com/spf13/cobra"
@@ -35,23 +34,10 @@ func offRun(cmd *cobra.Command, args []string) {
 	vmNames := args
 	infraLog.DefaultLogger.Debugf("Turning off the instances %s", strings.Join(vmNames, ", "))
 
-	// parse config
-	cnf, err := config.ParseConfig(CnfPath)
+	vms, err := cli.ResolveVMsByName(CnfPath, vmNames)
 	if err != nil {
-		console.Error(fmt.Sprintf("Failed to parse config: %v\n", err))
+		console.Error(fmt.Sprintf("%v\n", err))
 		os.Exit(1)
-	}
-	infraLog.DefaultLogger.Debug(fmt.Sprintf("Config: %+v", cnf))
-
-	// domain entity変換
-	var vms []*model.VM
-	for _, vmName := range vmNames {
-		vm := cnf.GetVMByName(vmName)
-		if vm == nil {
-			console.Error(fmt.Sprintf("VM %s not found", vmName))
-			os.Exit(1)
-		}
-		vms = append(vms, vm)
 	}
 
 	// 依存性の注入
@@ -72,7 +58,7 @@ func offRun(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	console.Success(fmt.Sprintf("Turned on the instances: %v\n", strings.Join(vmNames, ", ")))
+	console.Success(fmt.Sprintf("Turned off the instances: %v\n", strings.Join(vmNames, ", ")))
 }
 
 func init() {

--- a/go/cmd/off.go
+++ b/go/cmd/off.go
@@ -41,7 +41,7 @@ func offRun(cmd *cobra.Command, args []string) {
 	}
 
 	// 依存性の注入
-	vmRepo := gcp.NewVMRepository(CnfPath, infraLog.DefaultLogger)
+	vmRepo := gcp.NewVMRepository(infraLog.DefaultLogger)
 	stopVMUseCase := usecase.NewStopVMUseCase(vmRepo, infraLog.DefaultLogger)
 
 	// Turn off the instances

--- a/go/cmd/on.go
+++ b/go/cmd/on.go
@@ -8,10 +8,9 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/haru-256/gcectl/internal/domain/model"
-	"github.com/haru-256/gcectl/internal/infrastructure/config"
 	"github.com/haru-256/gcectl/internal/infrastructure/gcp"
 	infraLog "github.com/haru-256/gcectl/internal/infrastructure/log"
+	"github.com/haru-256/gcectl/internal/interface/cli"
 	"github.com/haru-256/gcectl/internal/interface/presenter"
 	"github.com/haru-256/gcectl/internal/usecase"
 	"github.com/spf13/cobra"
@@ -35,23 +34,10 @@ func onRun(cmd *cobra.Command, args []string) {
 	vmNames := args
 	infraLog.DefaultLogger.Debugf("Turning on the instances %s", strings.Join(vmNames, ", "))
 
-	// parse config
-	cnf, err := config.ParseConfig(CnfPath)
+	vms, err := cli.ResolveVMsByName(CnfPath, vmNames)
 	if err != nil {
-		console.Error(fmt.Sprintf("Failed to parse config: %v\n", err))
+		console.Error(fmt.Sprintf("%v\n", err))
 		os.Exit(1)
-	}
-	infraLog.DefaultLogger.Debug(fmt.Sprintf("Config: %+v", cnf))
-
-	// domain entity変換
-	var vms []*model.VM
-	for _, vmName := range vmNames {
-		vm := cnf.GetVMByName(vmName)
-		if vm == nil {
-			console.Error(fmt.Sprintf("VM %s not found", vmName))
-			os.Exit(1)
-		}
-		vms = append(vms, vm)
 	}
 
 	// 依存性の注入

--- a/go/cmd/on.go
+++ b/go/cmd/on.go
@@ -41,7 +41,7 @@ func onRun(cmd *cobra.Command, args []string) {
 	}
 
 	// 依存性の注入
-	vmRepo := gcp.NewVMRepository(CnfPath, infraLog.DefaultLogger)
+	vmRepo := gcp.NewVMRepository(infraLog.DefaultLogger)
 	startVMUseCase := usecase.NewStartVMUseCase(vmRepo, infraLog.DefaultLogger)
 
 	// Turn on the instances

--- a/go/cmd/set/machine_type.go
+++ b/go/cmd/set/machine_type.go
@@ -7,9 +7,9 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/haru-256/gcectl/internal/infrastructure/config"
 	"github.com/haru-256/gcectl/internal/infrastructure/gcp"
 	infraLog "github.com/haru-256/gcectl/internal/infrastructure/log"
+	"github.com/haru-256/gcectl/internal/interface/cli"
 	"github.com/haru-256/gcectl/internal/interface/presenter"
 	"github.com/haru-256/gcectl/internal/usecase"
 	"github.com/spf13/cobra"
@@ -38,18 +38,9 @@ Example:
 			os.Exit(1)
 		}
 
-		// parse config
-		cnf, err := config.ParseConfig(cnfPath)
+		vm, err := cli.ResolveVMByName(cnfPath, vmName)
 		if err != nil {
-			console.Error(fmt.Sprintf("Failed to parse config: %v\n", err))
-			os.Exit(1)
-		}
-		infraLog.DefaultLogger.Debugf(fmt.Sprintf("Config: %+v", cnf))
-
-		// filter VM by name
-		vm := cnf.GetVMByName(vmName)
-		if vm == nil {
-			console.Error(fmt.Sprintf("VM %s not found", vmName))
+			console.Error(fmt.Sprintf("%v\n", err))
 			os.Exit(1)
 		}
 

--- a/go/cmd/set/machine_type.go
+++ b/go/cmd/set/machine_type.go
@@ -45,7 +45,7 @@ Example:
 		}
 
 		// 依存性の注入
-		vmRepo := gcp.NewVMRepository(cnfPath, infraLog.DefaultLogger)
+		vmRepo := gcp.NewVMRepository(infraLog.DefaultLogger)
 		updateMachineTypeUseCase := usecase.NewUpdateMachineTypeUseCase(vmRepo, infraLog.DefaultLogger)
 
 		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)

--- a/go/cmd/set/schedule.go
+++ b/go/cmd/set/schedule.go
@@ -7,9 +7,9 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/haru-256/gcectl/internal/infrastructure/config"
 	"github.com/haru-256/gcectl/internal/infrastructure/gcp"
 	infraLog "github.com/haru-256/gcectl/internal/infrastructure/log"
+	"github.com/haru-256/gcectl/internal/interface/cli"
 	"github.com/haru-256/gcectl/internal/interface/presenter"
 	"github.com/haru-256/gcectl/internal/usecase"
 	"github.com/spf13/cobra"
@@ -38,18 +38,9 @@ Example:
 			os.Exit(1)
 		}
 
-		// parse config
-		cnf, err := config.ParseConfig(cnfPath)
+		vm, err := cli.ResolveVMByName(cnfPath, vmName)
 		if err != nil {
-			console.Error(fmt.Sprintf("Failed to parse config: %v\n", err))
-			os.Exit(1)
-		}
-		infraLog.DefaultLogger.Debugf(fmt.Sprintf("Config: %+v", cnf))
-
-		// filter VM by name
-		vm := cnf.GetVMByName(vmName)
-		if vm == nil {
-			console.Error(fmt.Sprintf("VM %s not found", vmName))
+			console.Error(fmt.Sprintf("%v\n", err))
 			os.Exit(1)
 		}
 

--- a/go/cmd/set/schedule.go
+++ b/go/cmd/set/schedule.go
@@ -45,7 +45,7 @@ Example:
 		}
 
 		// 依存性の注入
-		vmRepo := gcp.NewVMRepository(cnfPath, infraLog.DefaultLogger)
+		vmRepo := gcp.NewVMRepository(infraLog.DefaultLogger)
 
 		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 		defer stop()

--- a/go/internal/domain/model/vm.go
+++ b/go/internal/domain/model/vm.go
@@ -137,6 +137,13 @@ func (v *VM) CanStop() bool {
 	return v.Status == StatusRunning
 }
 
+// CanChangeMachineType checks if the VM can have its machine type changed.
+//
+// GCE requires an instance to be stopped before changing its machine type.
+func (v *VM) CanChangeMachineType() bool {
+	return v.Status == StatusStopped || v.Status == StatusTerminated
+}
+
 var (
 	ErrVMNotRunning = errors.New("VM is not running")
 	ErrNoStartTime  = errors.New("VM start time is not available")

--- a/go/internal/domain/model/vm_test.go
+++ b/go/internal/domain/model/vm_test.go
@@ -179,6 +179,48 @@ func TestVM_CanStop(t *testing.T) {
 	}
 }
 
+func TestVM_CanChangeMachineType(t *testing.T) {
+	tests := []struct {
+		name   string
+		status Status
+		want   bool
+	}{
+		{
+			name:   "can change machine type when stopped",
+			status: StatusStopped,
+			want:   true,
+		},
+		{
+			name:   "can change machine type when terminated",
+			status: StatusTerminated,
+			want:   true,
+		},
+		{
+			name:   "cannot change machine type when running",
+			status: StatusRunning,
+			want:   false,
+		},
+		{
+			name:   "cannot change machine type when provisioning",
+			status: StatusProvisioning,
+			want:   false,
+		},
+		{
+			name:   "cannot change machine type when unknown",
+			status: StatusUnknown,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vm := &VM{Status: tt.status}
+			got := vm.CanChangeMachineType()
+			assert.Equal(t, tt.want, got, "VM.CanChangeMachineType() with status %v should return %v", tt.status, tt.want)
+		})
+	}
+}
+
 func TestVM_Uptime(t *testing.T) {
 	startTime := time.Date(2025, 10, 11, 10, 0, 0, 0, time.UTC)
 	now := time.Date(2025, 10, 11, 12, 30, 0, 0, time.UTC)

--- a/go/internal/domain/repository/vm_repository.go
+++ b/go/internal/domain/repository/vm_repository.go
@@ -13,9 +13,6 @@ type VMRepository interface {
 	// FindByName retrieves a VM by its name, project, and zone
 	FindByName(ctx context.Context, vm *model.VM) (*model.VM, error)
 
-	// FindAll retrieves all VMs from the configuration
-	FindAll(ctx context.Context) ([]*model.VM, error)
-
 	// Start starts a VM instance
 	Start(ctx context.Context, vm *model.VM) error
 

--- a/go/internal/infrastructure/gcp/schedule_policy_test.go
+++ b/go/internal/infrastructure/gcp/schedule_policy_test.go
@@ -35,6 +35,14 @@ func TestFormatInstanceSchedulePolicy(t *testing.T) {
 			want: "nightly-stop",
 		},
 		{
+			name:       "empty schedule returns policy name",
+			policyName: "nightly-stop",
+			policy: &computepb.ResourcePolicyInstanceSchedulePolicy{
+				VmStopSchedule: &computepb.ResourcePolicyInstanceSchedulePolicySchedule{Schedule: stringPtr("")},
+			},
+			want: "nightly-stop",
+		},
+		{
 			name:       "schedule returns policy name with schedule",
 			policyName: "nightly-stop",
 			policy: &computepb.ResourcePolicyInstanceSchedulePolicy{

--- a/go/internal/infrastructure/gcp/schedule_policy_test.go
+++ b/go/internal/infrastructure/gcp/schedule_policy_test.go
@@ -1,0 +1,57 @@
+package gcp
+
+import (
+	"testing"
+
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatInstanceSchedulePolicy(t *testing.T) {
+	tests := []struct {
+		name       string
+		policyName string
+		policy     *computepb.ResourcePolicyInstanceSchedulePolicy
+		want       string
+	}{
+		{
+			name:       "nil policy returns empty string",
+			policyName: "nightly-stop",
+			policy:     nil,
+			want:       "",
+		},
+		{
+			name:       "nil stop schedule returns policy name",
+			policyName: "nightly-stop",
+			policy:     &computepb.ResourcePolicyInstanceSchedulePolicy{},
+			want:       "nightly-stop",
+		},
+		{
+			name:       "nil schedule returns policy name",
+			policyName: "nightly-stop",
+			policy: &computepb.ResourcePolicyInstanceSchedulePolicy{
+				VmStopSchedule: &computepb.ResourcePolicyInstanceSchedulePolicySchedule{},
+			},
+			want: "nightly-stop",
+		},
+		{
+			name:       "schedule returns policy name with schedule",
+			policyName: "nightly-stop",
+			policy: &computepb.ResourcePolicyInstanceSchedulePolicy{
+				VmStopSchedule: &computepb.ResourcePolicyInstanceSchedulePolicySchedule{Schedule: stringPtr("0 22 * * *")},
+			},
+			want: "nightly-stop(0 22 * * *)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatInstanceSchedulePolicy(tt.policyName, tt.policy)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func stringPtr(v string) *string {
+	return &v
+}

--- a/go/internal/infrastructure/gcp/vm_repository_impl.go
+++ b/go/internal/infrastructure/gcp/vm_repository_impl.go
@@ -19,22 +19,19 @@ import (
 //
 //nolint:govet // Field order optimized for readability over memory alignment
 type VMRepository struct {
-	configPath string
-	logger     log.Logger
+	logger log.Logger
 }
 
 // NewVMRepository creates a new VMRepository instance.
 //
 // Parameters:
-//   - configPath: Path to the configuration file
 //   - logger: Logger instance for logging
 //
 // Returns:
 //   - *VMRepository: A new repository instance
-func NewVMRepository(configPath string, logger log.Logger) *VMRepository {
+func NewVMRepository(logger log.Logger) *VMRepository {
 	return &VMRepository{
-		configPath: configPath,
-		logger:     logger,
+		logger: logger,
 	}
 }
 
@@ -367,7 +364,11 @@ func formatInstanceSchedulePolicy(policyName string, schedulePolicy *computepb.R
 	if schedulePolicy.VmStopSchedule == nil || schedulePolicy.VmStopSchedule.Schedule == nil {
 		return policyName
 	}
-	return fmt.Sprintf("%s(%s)", policyName, schedulePolicy.VmStopSchedule.GetSchedule())
+	schedule := schedulePolicy.VmStopSchedule.GetSchedule()
+	if schedule == "" {
+		return policyName
+	}
+	return fmt.Sprintf("%s(%s)", policyName, schedule)
 }
 
 func extractMachineType(fullURI string) string {

--- a/go/internal/infrastructure/gcp/vm_repository_impl.go
+++ b/go/internal/infrastructure/gcp/vm_repository_impl.go
@@ -9,11 +9,9 @@ import (
 
 	compute "cloud.google.com/go/compute/apiv1"
 	"cloud.google.com/go/compute/apiv1/computepb"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/haru-256/gcectl/internal/domain/model"
 	"github.com/haru-256/gcectl/internal/domain/repository"
-	"github.com/haru-256/gcectl/internal/infrastructure/config"
 	"github.com/haru-256/gcectl/internal/infrastructure/log"
 )
 
@@ -40,16 +38,22 @@ func NewVMRepository(configPath string, logger log.Logger) *VMRepository {
 	}
 }
 
+func (r *VMRepository) newInstancesClient(ctx context.Context) (*compute.InstancesClient, error) {
+	return compute.NewInstancesRESTClient(ctx)
+}
+
+func (r *VMRepository) closeInstancesClient(client *compute.InstancesClient) {
+	if closeErr := client.Close(); closeErr != nil {
+		r.logger.Errorf("Failed to close client: %v", closeErr)
+	}
+}
+
 func (r *VMRepository) FindByName(ctx context.Context, vm *model.VM) (*model.VM, error) {
-	client, err := compute.NewInstancesRESTClient(ctx)
+	client, err := r.newInstancesClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create client: %w", err)
 	}
-	defer func() {
-		if closeErr := client.Close(); closeErr != nil {
-			r.logger.Errorf("Failed to close client: %v", closeErr)
-		}
-	}()
+	defer r.closeInstancesClient(client)
 
 	req := &computepb.GetInstanceRequest{
 		Project:  vm.Project,
@@ -65,56 +69,12 @@ func (r *VMRepository) FindByName(ctx context.Context, vm *model.VM) (*model.VM,
 	return r.toModel(ctx, instance)
 }
 
-func (r *VMRepository) FindAll(ctx context.Context) ([]*model.VM, error) {
-	// 設定ファイルから VM リストを読み込み
-	cfg, err := config.ParseConfig(r.configPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load config: %w", err)
-	}
-
-	// errgroup を使用して並行実行
-	eg, ctx := errgroup.WithContext(ctx)
-	vmChan := make(chan *model.VM, len(cfg.VMs))
-
-	for _, cfgVM := range cfg.VMs {
-		cfgVM := cfgVM // ループ変数のキャプチャ
-		eg.Go(func() error {
-			vm, findErr := r.FindByName(ctx, cfgVM)
-			if findErr != nil {
-				// エラーをログに記録して続行
-				r.logger.Errorf("failed to find VM %s in project %s zone %s: %v", cfgVM.Name, cfgVM.Project, cfgVM.Zone, findErr)
-				return nil // エラーを返さずに続行
-			}
-			vmChan <- vm
-			return nil
-		})
-	}
-
-	// すべてのゴルーチンが完了するのを待つ
-	if waitErr := eg.Wait(); waitErr != nil {
-		return nil, fmt.Errorf("failed to fetch VMs: %w", waitErr)
-	}
-	close(vmChan)
-
-	// チャネルから結果を収集
-	vms := make([]*model.VM, 0, len(cfg.VMs))
-	for vm := range vmChan {
-		vms = append(vms, vm)
-	}
-
-	return vms, nil
-}
-
 func (r *VMRepository) Start(ctx context.Context, vm *model.VM) error {
-	client, err := compute.NewInstancesRESTClient(ctx)
+	client, err := r.newInstancesClient(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)
 	}
-	defer func() {
-		if closeErr := client.Close(); closeErr != nil {
-			r.logger.Errorf("Failed to close client: %v", closeErr)
-		}
-	}()
+	defer r.closeInstancesClient(client)
 
 	req := &computepb.StartInstanceRequest{
 		Project:  vm.Project,
@@ -131,15 +91,11 @@ func (r *VMRepository) Start(ctx context.Context, vm *model.VM) error {
 }
 
 func (r *VMRepository) Stop(ctx context.Context, vm *model.VM) error {
-	client, err := compute.NewInstancesRESTClient(ctx)
+	client, err := r.newInstancesClient(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)
 	}
-	defer func() {
-		if closeErr := client.Close(); closeErr != nil {
-			r.logger.Errorf("Failed to close client: %v", closeErr)
-		}
-	}()
+	defer r.closeInstancesClient(client)
 
 	req := &computepb.StopInstanceRequest{
 		Project:  vm.Project,
@@ -158,16 +114,12 @@ func (r *VMRepository) Stop(ctx context.Context, vm *model.VM) error {
 // SetSchedulePolicy attaches a schedule policy to a Google Compute Engine instance.
 func (r *VMRepository) SetSchedulePolicy(ctx context.Context, vm *model.VM, policyName string) error {
 	// Create a new InstancesClient with authentication
-	client, err := compute.NewInstancesRESTClient(ctx)
+	client, err := r.newInstancesClient(ctx)
 	if err != nil {
 		r.logger.Errorf("failed to create Instances client: %v", err)
 		return fmt.Errorf("failed to create client: %w", err)
 	}
-	defer func() {
-		if closeErr := client.Close(); closeErr != nil {
-			r.logger.Errorf("Failed to close client: %v", closeErr)
-		}
-	}()
+	defer r.closeInstancesClient(client)
 
 	// Get instance details
 	req := &computepb.GetInstanceRequest{
@@ -219,16 +171,12 @@ func (r *VMRepository) SetSchedulePolicy(ctx context.Context, vm *model.VM, poli
 // UnsetSchedulePolicy removes a schedule policy from a Google Compute Engine instance.
 func (r *VMRepository) UnsetSchedulePolicy(ctx context.Context, vm *model.VM, policyName string) error {
 	// Create a new InstancesClient with authentication
-	client, err := compute.NewInstancesRESTClient(ctx)
+	client, err := r.newInstancesClient(ctx)
 	if err != nil {
 		r.logger.Errorf("failed to create Instances client: %v", err)
 		return fmt.Errorf("failed to create client: %w", err)
 	}
-	defer func() {
-		if closeErr := client.Close(); closeErr != nil {
-			r.logger.Errorf("Failed to close client: %v", closeErr)
-		}
-	}()
+	defer r.closeInstancesClient(client)
 
 	// Get instance details
 	req := &computepb.GetInstanceRequest{
@@ -280,16 +228,12 @@ func (r *VMRepository) UnsetSchedulePolicy(ctx context.Context, vm *model.VM, po
 // UpdateMachineType changes the machine type of a VM instance.
 func (r *VMRepository) UpdateMachineType(ctx context.Context, vm *model.VM, machineType string) error {
 	// Create a new InstancesClient with authentication
-	client, err := compute.NewInstancesRESTClient(ctx)
+	client, err := r.newInstancesClient(ctx)
 	if err != nil {
 		r.logger.Errorf("failed to create Instances client: %v", err)
 		return fmt.Errorf("failed to create client: %w", err)
 	}
-	defer func() {
-		if closeErr := client.Close(); closeErr != nil {
-			r.logger.Errorf("Failed to close client: %v", closeErr)
-		}
-	}()
+	defer r.closeInstancesClient(client)
 
 	// Machine type must be in the format: zones/ZONE/machineTypes/MACHINE_TYPE
 	machineTypeURL := fmt.Sprintf("zones/%s/machineTypes/%s", vm.Zone, machineType)
@@ -359,11 +303,9 @@ func (r *VMRepository) toModel(ctx context.Context, instance *computepb.Instance
 }
 
 func (r *VMRepository) getSchedulePolicy(ctx context.Context, instance *computepb.Instance) (string, error) {
-	defaultPolicy := "#NONE"
-
 	policies := instance.GetResourcePolicies()
 	if len(policies) == 0 {
-		return defaultPolicy, nil
+		return "", nil
 	}
 
 	policyClient, err := compute.NewResourcePoliciesRESTClient(ctx)
@@ -410,12 +352,22 @@ func (r *VMRepository) getSchedulePolicy(ctx context.Context, instance *computep
 		}
 
 		schedulePolicy := resourcePolicy.GetInstanceSchedulePolicy()
-		if schedulePolicy != nil {
-			return fmt.Sprintf("%s(%s)", policyName, *schedulePolicy.VmStopSchedule.Schedule), nil
+		if formattedPolicy := formatInstanceSchedulePolicy(policyName, schedulePolicy); formattedPolicy != "" {
+			return formattedPolicy, nil
 		}
 	}
 
-	return defaultPolicy, nil
+	return "", nil
+}
+
+func formatInstanceSchedulePolicy(policyName string, schedulePolicy *computepb.ResourcePolicyInstanceSchedulePolicy) string {
+	if schedulePolicy == nil {
+		return ""
+	}
+	if schedulePolicy.VmStopSchedule == nil || schedulePolicy.VmStopSchedule.Schedule == nil {
+		return policyName
+	}
+	return fmt.Sprintf("%s(%s)", policyName, schedulePolicy.VmStopSchedule.GetSchedule())
 }
 
 func extractMachineType(fullURI string) string {

--- a/go/internal/infrastructure/gcp/vm_repository_impl_test.go
+++ b/go/internal/infrastructure/gcp/vm_repository_impl_test.go
@@ -82,32 +82,6 @@ func TestVMRepositoryImpl_FindByName(t *testing.T) {
 	}
 }
 
-func TestVMRepositoryImpl_FindAll(t *testing.T) {
-	cnf, cnfPath := getCnf(t)
-	repo := gcp.NewVMRepository(cnfPath, logger)
-	ctx := context.Background()
-
-	vms, err := repo.FindAll(ctx)
-	require.NoError(t, err)
-	require.NotNil(t, vms)
-	require.GreaterOrEqual(t, len(vms), len(cnf.VMs), "Should find at least the configured VMs")
-
-	// Verify that all configured VMs are found
-	for _, configVM := range cnf.VMs {
-		found := false
-		for _, vm := range vms {
-			if vm.Project == configVM.Project && vm.Zone == configVM.Zone && vm.Name == configVM.Name {
-				found = true
-				// Verify required fields are populated
-				assert.NotEmpty(t, vm.MachineType)
-				assert.NotEqual(t, model.StatusUnknown, vm.Status)
-				break
-			}
-		}
-		assert.True(t, found, "Configured VM %s/%s/%s should be found", configVM.Project, configVM.Zone, configVM.Name)
-	}
-}
-
 func TestVMRepositoryImpl_StartStop(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping long-running integration test in short mode")

--- a/go/internal/infrastructure/gcp/vm_repository_impl_test.go
+++ b/go/internal/infrastructure/gcp/vm_repository_impl_test.go
@@ -33,8 +33,8 @@ func getCnf(t *testing.T) (*config.Config, string) {
 }
 
 func TestVMRepositoryImpl_FindByName(t *testing.T) {
-	cnf, cnfPath := getCnf(t)
-	repo := gcp.NewVMRepository(cnfPath, logger)
+	cnf, _ := getCnf(t)
+	repo := gcp.NewVMRepository(logger)
 	ctx := context.Background()
 
 	tests := []struct {
@@ -87,8 +87,8 @@ func TestVMRepositoryImpl_StartStop(t *testing.T) {
 		t.Skip("Skipping long-running integration test in short mode")
 	}
 
-	cnf, cnfPath := getCnf(t)
-	repo := gcp.NewVMRepository(cnfPath, logger)
+	cnf, _ := getCnf(t)
+	repo := gcp.NewVMRepository(logger)
 	ctx := context.Background()
 
 	// Use the first configured VM for testing
@@ -168,8 +168,8 @@ func TestVMRepositoryImpl_UpdateMachineType(t *testing.T) {
 		t.Skip("Skipping long-running integration test in short mode")
 	}
 
-	cnf, cnfPath := getCnf(t)
-	repo := gcp.NewVMRepository(cnfPath, logger)
+	cnf, _ := getCnf(t)
+	repo := gcp.NewVMRepository(logger)
 	ctx := context.Background()
 
 	// Use the first configured VM for testing
@@ -248,8 +248,8 @@ func TestVMRepositoryImpl_SchedulePolicy(t *testing.T) {
 		t.Skip("Skipping long-running integration test in short mode")
 	}
 
-	cnf, cnfPath := getCnf(t)
-	repo := gcp.NewVMRepository(cnfPath, logger)
+	cnf, _ := getCnf(t)
+	repo := gcp.NewVMRepository(logger)
 	ctx := context.Background()
 
 	// Use the first configured VM for testing

--- a/go/internal/interface/cli/config.go
+++ b/go/internal/interface/cli/config.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/haru-256/gcectl/internal/domain/model"
+	"github.com/haru-256/gcectl/internal/infrastructure/config"
+)
+
+// LoadConfig reads the gcectl configuration from disk.
+func LoadConfig(configPath string) (*config.Config, error) {
+	cfg, err := config.ParseConfig(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse config: %w", err)
+	}
+	return cfg, nil
+}
+
+// ResolveVMsByName loads configured VMs in the same order requested by name.
+func ResolveVMsByName(configPath string, names []string) ([]*model.VM, error) {
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	vms := make([]*model.VM, 0, len(names))
+	for _, name := range names {
+		vm := cfg.GetVMByName(name)
+		if vm == nil {
+			return nil, fmt.Errorf("VM %s not found", name)
+		}
+		vms = append(vms, vm)
+	}
+
+	return vms, nil
+}
+
+// ResolveVMByName loads one configured VM by name.
+func ResolveVMByName(configPath, name string) (*model.VM, error) {
+	vms, err := ResolveVMsByName(configPath, []string{name})
+	if err != nil {
+		return nil, err
+	}
+	return vms[0], nil
+}

--- a/go/internal/interface/cli/config_test.go
+++ b/go/internal/interface/cli/config_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfig(t *testing.T) {
+	configPath := writeConfig(t, `
+default-project: test-project
+default-zone: us-central1-a
+vm:
+  - name: test-vm
+`)
+
+	cfg, err := LoadConfig(configPath)
+
+	require.NoError(t, err)
+	require.Len(t, cfg.VMs, 1)
+	assert.Equal(t, "test-project", cfg.VMs[0].Project)
+	assert.Equal(t, "us-central1-a", cfg.VMs[0].Zone)
+}
+
+func TestResolveVMsByName(t *testing.T) {
+	configPath := writeConfig(t, `
+default-project: test-project
+default-zone: us-central1-a
+vm:
+  - name: vm-a
+  - name: vm-b
+    zone: asia-northeast1-a
+`)
+
+	vms, err := ResolveVMsByName(configPath, []string{"vm-b", "vm-a"})
+
+	require.NoError(t, err)
+	require.Len(t, vms, 2)
+	assert.Equal(t, "vm-b", vms[0].Name)
+	assert.Equal(t, "asia-northeast1-a", vms[0].Zone)
+	assert.Equal(t, "vm-a", vms[1].Name)
+	assert.Equal(t, "us-central1-a", vms[1].Zone)
+}
+
+func TestResolveVMsByNameReturnsMissingVM(t *testing.T) {
+	configPath := writeConfig(t, `
+default-project: test-project
+default-zone: us-central1-a
+vm:
+  - name: vm-a
+`)
+
+	vms, err := ResolveVMsByName(configPath, []string{"missing-vm"})
+
+	require.Error(t, err)
+	assert.Nil(t, vms)
+	assert.Contains(t, err.Error(), "VM missing-vm not found")
+}
+
+func writeConfig(t *testing.T, content string) string {
+	t.Helper()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(content), 0o600))
+	return configPath
+}

--- a/go/internal/interface/presenter/console.go
+++ b/go/internal/interface/presenter/console.go
@@ -123,7 +123,7 @@ func (p *ConsolePresenter) RenderVMList(items []VMListItem) {
 			item.Zone,
 			item.MachineType,
 			statusEmoji + " " + item.Status.String(),
-			item.SchedulePolicy,
+			formatSchedulePolicy(item.SchedulePolicy),
 			item.Uptime,
 		})
 	}
@@ -167,11 +167,18 @@ func (p *ConsolePresenter) RenderVMDetail(detail VMDetail) {
 		fmt.Sprintf("%s%s: %s", prefixStyle.Render(listItemsHeader[2]), itemPaddings[2], detail.Zone),
 		fmt.Sprintf("%s%s: %s", prefixStyle.Render(listItemsHeader[3]), itemPaddings[3], detail.MachineType),
 		fmt.Sprintf("%s%s: %s", prefixStyle.Render(listItemsHeader[4]), itemPaddings[4], detail.Status.String()),
-		fmt.Sprintf("%s%s: %s", prefixStyle.Render(listItemsHeader[5]), itemPaddings[5], detail.SchedulePolicy),
+		fmt.Sprintf("%s%s: %s", prefixStyle.Render(listItemsHeader[5]), itemPaddings[5], formatSchedulePolicy(detail.SchedulePolicy)),
 		fmt.Sprintf("%s%s: %s", prefixStyle.Render(listItemsHeader[6]), itemPaddings[6], detail.Uptime),
 	).Enumerator(list.Bullet).EnumeratorStyle(lipgloss.NewStyle().Padding(0, 1))
 
 	fmt.Println(l)
+}
+
+func formatSchedulePolicy(policy string) string {
+	if policy == "" {
+		return "#NONE"
+	}
+	return policy
 }
 
 // RenderVersion renders version information in a list format.

--- a/go/internal/interface/presenter/console_test.go
+++ b/go/internal/interface/presenter/console_test.go
@@ -327,6 +327,32 @@ func TestGetStatusEmoji(t *testing.T) {
 	}
 }
 
+func TestFormatSchedulePolicy(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy string
+		want   string
+	}{
+		{
+			name:   "empty policy displays none",
+			policy: "",
+			want:   "#NONE",
+		},
+		{
+			name:   "non-empty policy is unchanged",
+			policy: "nightly-stop(0 22 * * *)",
+			want:   "nightly-stop(0 22 * * *)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatSchedulePolicy(tt.policy)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestGetItemPaddings(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/go/internal/mock/repository/vm_repository_mock.go
+++ b/go/internal/mock/repository/vm_repository_mock.go
@@ -41,21 +41,6 @@ func (m *MockVMRepository) EXPECT() *MockVMRepositoryMockRecorder {
 	return m.recorder
 }
 
-// FindAll mocks base method.
-func (m *MockVMRepository) FindAll(ctx context.Context) ([]*model.VM, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindAll", ctx)
-	ret0, _ := ret[0].([]*model.VM)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FindAll indicates an expected call of FindAll.
-func (mr *MockVMRepositoryMockRecorder) FindAll(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAll", reflect.TypeOf((*MockVMRepository)(nil).FindAll), ctx)
-}
-
 // FindByName mocks base method.
 func (m *MockVMRepository) FindByName(ctx context.Context, vm *model.VM) (*model.VM, error) {
 	m.ctrl.T.Helper()

--- a/go/internal/usecase/describe_vm.go
+++ b/go/internal/usecase/describe_vm.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/haru-256/gcectl/internal/domain/model"
@@ -26,7 +27,6 @@ func NewDescribeVMUseCase(repo repository.VMRepository) *DescribeVMUseCase {
 //
 // Parameters:
 //   - ctx: Context for cancellation and timeout control
-//   - repo: VM repository interface for data access
 //   - project: GCP project ID
 //   - zone: GCP zone
 //   - name: VM instance name
@@ -38,7 +38,8 @@ func NewDescribeVMUseCase(repo repository.VMRepository) *DescribeVMUseCase {
 //
 // Example:
 //
-//	vm, uptime, err := DescribeVM(ctx, repo, "my-project", "us-central1-a", "my-vm")
+//	useCase := NewDescribeVMUseCase(repo)
+//	vm, uptime, err := useCase.Execute(ctx, "my-project", "us-central1-a", "my-vm")
 //	if err != nil {
 //	    return err
 //	}
@@ -53,6 +54,9 @@ func (u *DescribeVMUseCase) Execute(ctx context.Context, project, zone, name str
 	foundVM, err := u.repo.FindByName(ctx, vm)
 	if err != nil {
 		return nil, "", err
+	}
+	if foundVM == nil {
+		return nil, "", fmt.Errorf("VM %s: not found", name)
 	}
 
 	// Calculate uptime using shared logic

--- a/go/internal/usecase/describe_vm.go
+++ b/go/internal/usecase/describe_vm.go
@@ -8,7 +8,17 @@ import (
 	"github.com/haru-256/gcectl/internal/domain/repository"
 )
 
-// DescribeVM retrieves detailed information about a specific VM and returns it with a calculated uptime string.
+// DescribeVMUseCase retrieves detailed information about a specific VM.
+type DescribeVMUseCase struct {
+	repo repository.VMRepository
+}
+
+// NewDescribeVMUseCase creates a new DescribeVMUseCase instance.
+func NewDescribeVMUseCase(repo repository.VMRepository) *DescribeVMUseCase {
+	return &DescribeVMUseCase{repo: repo}
+}
+
+// Execute retrieves detailed information about a specific VM and returns it with a calculated uptime string.
 //
 // This use case encapsulates the business logic of fetching a VM and calculating its uptime,
 // keeping this logic out of the presentation layer. The uptime is returned as a formatted string
@@ -34,13 +44,13 @@ import (
 //	}
 //	// vm: &model.VM{Name: "my-vm", Status: model.StatusRunning, ...}
 //	// uptime: "2h30m15s"
-func DescribeVM(ctx context.Context, repo repository.VMRepository, project, zone, name string) (*model.VM, string, error) {
+func (u *DescribeVMUseCase) Execute(ctx context.Context, project, zone, name string) (*model.VM, string, error) {
 	vm := &model.VM{
 		Project: project,
 		Zone:    zone,
 		Name:    name,
 	}
-	foundVM, err := repo.FindByName(ctx, vm)
+	foundVM, err := u.repo.FindByName(ctx, vm)
 	if err != nil {
 		return nil, "", err
 	}

--- a/go/internal/usecase/describe_vm_test.go
+++ b/go/internal/usecase/describe_vm_test.go
@@ -114,6 +114,25 @@ func TestDescribeVM(t *testing.T) {
 			wantUptime: "",
 			wantErr:    true,
 		},
+		{
+			name:    "repository returns nil VM without error",
+			project: "test-project",
+			zone:    "us-central1-a",
+			vmName:  "missing-vm",
+			setupMock: func(m *mock_repository.MockVMRepository) {
+				expectedVM := &model.VM{
+					Name:    "missing-vm",
+					Project: "test-project",
+					Zone:    "us-central1-a",
+				}
+				m.EXPECT().
+					FindByName(gomock.Any(), gomock.Any()).
+					DoAndReturn(testhelpers.VMFindByNameMatcher(t, expectedVM, nil, nil))
+			},
+			wantVM:     nil,
+			wantUptime: "",
+			wantErr:    true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/go/internal/usecase/describe_vm_test.go
+++ b/go/internal/usecase/describe_vm_test.go
@@ -124,7 +124,8 @@ func TestDescribeVM(t *testing.T) {
 			mockRepo := mock_repository.NewMockVMRepository(ctrl)
 			tt.setupMock(mockRepo)
 
-			vm, uptime, err := DescribeVM(context.Background(), mockRepo, tt.project, tt.zone, tt.vmName)
+			useCase := NewDescribeVMUseCase(mockRepo)
+			vm, uptime, err := useCase.Execute(context.Background(), tt.project, tt.zone, tt.vmName)
 
 			if tt.wantErr {
 				assert.Error(t, err, "DescribeVM() should return an error")

--- a/go/internal/usecase/list_vms.go
+++ b/go/internal/usecase/list_vms.go
@@ -2,13 +2,17 @@ package usecase
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/haru-256/gcectl/internal/domain/model"
 	"github.com/haru-256/gcectl/internal/domain/repository"
 	"golang.org/x/sync/errgroup"
 )
+
+const maxConcurrentVMLookups = 10
 
 // VMListItem represents a VM with its display information including uptime.
 // This struct is used to pass presentation-ready data from the use case layer
@@ -39,23 +43,24 @@ func NewListVMsUseCase(repo repository.VMRepository) *ListVMsUseCase {
 // Execute retrieves the configured VMs and calculates their uptime strings.
 //
 // This method encapsulates the business logic of calculating uptime,
-// which should not be in the presentation layer. For each VM, it:
-//   - Calls the shared calculateUptimeString() function
-//   - Returns "N/A" for VMs that are not running or have errors
+// which should not be in the presentation layer. VM lookups are best-effort:
+// successful lookups are returned, while failed lookups are collected into the
+// returned error so the caller can still render partial results.
 //
 // Parameters:
 //   - ctx: Context for cancellation and timeout control
+//   - configuredVMs: VMs loaded from config to query from the repository
 //
 // Returns:
-//   - []VMListItem: List of VMs with their calculated uptime strings
-//   - error: Error if VM retrieval fails
+//   - []VMListItem: Successfully retrieved VMs with calculated uptime strings
+//   - error: Joined error for failed VM lookups, or nil if all lookups succeed
 //
 // Example:
 //
 //	useCase := NewListVMsUseCase(repo)
-//	items, err := useCase.Execute(ctx)
+//	items, err := useCase.Execute(ctx, configuredVMs)
 //	if err != nil {
-//	    return err
+//	    fmt.Fprintf(os.Stderr, "some VMs could not be listed: %v\n", err)
 //	}
 //	for _, item := range items {
 //	    fmt.Printf("%s: %s\n", item.VM.Name, item.Uptime)
@@ -63,17 +68,27 @@ func NewListVMsUseCase(repo repository.VMRepository) *ListVMsUseCase {
 func (u *ListVMsUseCase) Execute(ctx context.Context, configuredVMs []*model.VM) ([]VMListItem, error) {
 	now := time.Now()
 	items := make([]VMListItem, len(configuredVMs))
+	errs := make([]error, 0)
+	var mu sync.Mutex
+
 	eg, ctx := errgroup.WithContext(ctx)
+	eg.SetLimit(maxConcurrentVMLookups)
 
 	for i, configuredVM := range configuredVMs {
 		i, configuredVM := i, configuredVM
 		eg.Go(func() error {
 			vm, err := u.repo.FindByName(ctx, configuredVM)
 			if err != nil {
-				return fmt.Errorf("failed to find VM %s: %w", configuredVM.Name, err)
+				mu.Lock()
+				errs = append(errs, fmt.Errorf("failed to find VM %s: %w", configuredVM.Name, err))
+				mu.Unlock()
+				return nil
 			}
 			if vm == nil {
-				return fmt.Errorf("VM %s: not found", configuredVM.Name)
+				mu.Lock()
+				errs = append(errs, fmt.Errorf("VM %s: not found", configuredVM.Name))
+				mu.Unlock()
+				return nil
 			}
 
 			items[i] = VMListItem{
@@ -88,5 +103,12 @@ func (u *ListVMsUseCase) Execute(ctx context.Context, configuredVMs []*model.VM)
 		return nil, err
 	}
 
-	return items, nil
+	successfulItems := make([]VMListItem, 0, len(items))
+	for _, item := range items {
+		if item.VM != nil {
+			successfulItems = append(successfulItems, item)
+		}
+	}
+
+	return successfulItems, errors.Join(errs...)
 }

--- a/go/internal/usecase/list_vms.go
+++ b/go/internal/usecase/list_vms.go
@@ -2,10 +2,12 @@ package usecase
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/haru-256/gcectl/internal/domain/model"
 	"github.com/haru-256/gcectl/internal/domain/repository"
+	"golang.org/x/sync/errgroup"
 )
 
 // VMListItem represents a VM with its display information including uptime.
@@ -34,7 +36,7 @@ func NewListVMsUseCase(repo repository.VMRepository) *ListVMsUseCase {
 	}
 }
 
-// Execute retrieves all VMs and calculates their uptime strings.
+// Execute retrieves the configured VMs and calculates their uptime strings.
 //
 // This method encapsulates the business logic of calculating uptime,
 // which should not be in the presentation layer. For each VM, it:
@@ -58,19 +60,32 @@ func NewListVMsUseCase(repo repository.VMRepository) *ListVMsUseCase {
 //	for _, item := range items {
 //	    fmt.Printf("%s: %s\n", item.VM.Name, item.Uptime)
 //	}
-func (u *ListVMsUseCase) Execute(ctx context.Context) ([]VMListItem, error) {
-	vms, err := u.repo.FindAll(ctx)
-	if err != nil {
-		return nil, err
+func (u *ListVMsUseCase) Execute(ctx context.Context, configuredVMs []*model.VM) ([]VMListItem, error) {
+	now := time.Now()
+	items := make([]VMListItem, len(configuredVMs))
+	eg, ctx := errgroup.WithContext(ctx)
+
+	for i, configuredVM := range configuredVMs {
+		i, configuredVM := i, configuredVM
+		eg.Go(func() error {
+			vm, err := u.repo.FindByName(ctx, configuredVM)
+			if err != nil {
+				return fmt.Errorf("failed to find VM %s: %w", configuredVM.Name, err)
+			}
+			if vm == nil {
+				return fmt.Errorf("VM %s: not found", configuredVM.Name)
+			}
+
+			items[i] = VMListItem{
+				VM:     vm,
+				Uptime: calculateUptimeString(vm, now),
+			}
+			return nil
+		})
 	}
 
-	now := time.Now()
-	items := make([]VMListItem, len(vms))
-	for i, vm := range vms {
-		items[i] = VMListItem{
-			VM:     vm,
-			Uptime: calculateUptimeString(vm, now),
-		}
+	if err := eg.Wait(); err != nil {
+		return nil, err
 	}
 
 	return items, nil

--- a/go/internal/usecase/list_vms_test.go
+++ b/go/internal/usecase/list_vms_test.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -18,12 +19,12 @@ var errTestList = errors.New("test error")
 //nolint:gocognit // Test function is complex but readable with table-driven design
 func TestListVMsUseCase_Execute(t *testing.T) {
 	tests := []struct {
-		name        string
-		configured  []*model.VM
-		wantUptimes []string // Expected uptime strings for each VM
-		setupMock   func(*mock_repository.MockVMRepository)
-		wantLen     int
-		wantError   bool
+		name                string
+		configured          []*model.VM
+		wantUptimeAvailable []bool
+		setupMock           func(*mock_repository.MockVMRepository)
+		wantLen             int
+		wantError           bool
 	}{
 		{
 			name: "single running VM with uptime",
@@ -41,9 +42,9 @@ func TestListVMsUseCase_Execute(t *testing.T) {
 				}
 				m.EXPECT().FindByName(gomock.Any(), gomock.Any()).Return(vm, nil)
 			},
-			wantLen:     1,
-			wantUptimes: []string{"2h0m0s"}, // Approximately 2 hours
-			wantError:   false,
+			wantLen:             1,
+			wantUptimeAvailable: []bool{true},
+			wantError:           false,
 		},
 		{
 			name: "stopped VM returns N/A uptime",
@@ -61,9 +62,9 @@ func TestListVMsUseCase_Execute(t *testing.T) {
 				}
 				m.EXPECT().FindByName(gomock.Any(), gomock.Any()).Return(vm, nil)
 			},
-			wantLen:     1,
-			wantUptimes: []string{"N/A"},
-			wantError:   false,
+			wantLen:             1,
+			wantUptimeAvailable: []bool{false},
+			wantError:           false,
 		},
 		{
 			name: "multiple VMs with mixed statuses",
@@ -104,9 +105,42 @@ func TestListVMsUseCase_Execute(t *testing.T) {
 						}
 					})
 			},
-			wantLen:     2,
-			wantUptimes: []string{"30m0s", "N/A"},
-			wantError:   false,
+			wantLen:             2,
+			wantUptimeAvailable: []bool{true, false},
+			wantError:           false,
+		},
+		{
+			name: "partial results with repository error",
+			configured: []*model.VM{
+				{Name: "running-vm", Project: "test-project", Zone: "us-central1-a"},
+				{Name: "missing-vm", Project: "test-project", Zone: "us-west1-a"},
+			},
+			setupMock: func(m *mock_repository.MockVMRepository) {
+				runningVM := &model.VM{
+					Name:          "running-vm",
+					Project:       "test-project",
+					Zone:          "us-central1-a",
+					MachineType:   "e2-medium",
+					Status:        model.StatusRunning,
+					LastStartTime: timePtr(time.Now().Add(-30 * time.Minute)),
+				}
+				m.EXPECT().
+					FindByName(gomock.Any(), gomock.Any()).
+					Times(2).
+					DoAndReturn(func(ctx context.Context, vm *model.VM) (*model.VM, error) {
+						switch vm.Name {
+						case "running-vm":
+							return runningVM, nil
+						case "missing-vm":
+							return nil, errTestList
+						default:
+							return nil, errors.New("unexpected VM")
+						}
+					})
+			},
+			wantLen:             1,
+			wantUptimeAvailable: []bool{true},
+			wantError:           true,
 		},
 		{
 			name: "repository error",
@@ -116,9 +150,9 @@ func TestListVMsUseCase_Execute(t *testing.T) {
 			setupMock: func(m *mock_repository.MockVMRepository) {
 				m.EXPECT().FindByName(gomock.Any(), gomock.Any()).Return(nil, errTestList)
 			},
-			wantLen:     0,
-			wantUptimes: nil,
-			wantError:   true,
+			wantLen:             0,
+			wantUptimeAvailable: nil,
+			wantError:           true,
 		},
 	}
 
@@ -135,30 +169,77 @@ func TestListVMsUseCase_Execute(t *testing.T) {
 
 			items, err := useCase.Execute(ctx, tt.configured)
 
-			// Check error
 			if tt.wantError {
 				assert.Error(t, err, "Execute() should return an error")
-				return
+			} else {
+				assert.NoError(t, err, "Execute() should not return an error")
 			}
 
-			assert.NoError(t, err, "Execute() should not return an error")
-
-			// Check length
 			require.Len(t, items, tt.wantLen, "Execute() should return %d items", tt.wantLen)
 
-			// Check uptime strings
 			for i, item := range items {
-				// For uptime, check if it's "N/A" or not
-				// Detailed format testing is covered in TestFormatUptime
-				if tt.wantUptimes[i] == "N/A" {
-					assert.Equal(t, "N/A", item.Uptime, "Execute() item[%d].Uptime should be N/A", i)
+				if tt.wantUptimeAvailable[i] {
+					assert.NotEqual(t, "N/A", item.Uptime, "Execute() item[%d].Uptime should contain uptime", i)
 				} else {
-					// For running VMs, just verify it's not "N/A"
-					assert.NotEqual(t, "N/A", item.Uptime, "Execute() item[%d].Uptime should not be N/A", i)
+					assert.Equal(t, "N/A", item.Uptime, "Execute() item[%d].Uptime should be N/A", i)
 				}
 			}
 		})
 	}
+}
+
+func TestListVMsUseCase_ExecuteLimitsConcurrentLookups(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	configured := make([]*model.VM, maxConcurrentVMLookups+1)
+	for i := range configured {
+		configured[i] = &model.VM{Name: "test-vm", Project: "test-project", Zone: "us-central1-a"}
+	}
+
+	var inFlight int32
+	var maxInFlight int32
+	release := make(chan struct{})
+	mockRepo := mock_repository.NewMockVMRepository(ctrl)
+	mockRepo.EXPECT().
+		FindByName(gomock.Any(), gomock.Any()).
+		Times(len(configured)).
+		DoAndReturn(func(ctx context.Context, vm *model.VM) (*model.VM, error) {
+			current := atomic.AddInt32(&inFlight, 1)
+			for {
+				previous := atomic.LoadInt32(&maxInFlight)
+				if current <= previous || atomic.CompareAndSwapInt32(&maxInFlight, previous, current) {
+					break
+				}
+			}
+			<-release
+			atomic.AddInt32(&inFlight, -1)
+			return &model.VM{
+				Name:          vm.Name,
+				Project:       vm.Project,
+				Zone:          vm.Zone,
+				MachineType:   "e2-medium",
+				Status:        model.StatusRunning,
+				LastStartTime: timePtr(time.Now().Add(-30 * time.Minute)),
+			}, nil
+		})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := NewListVMsUseCase(mockRepo).Execute(context.Background(), configured)
+		done <- err
+	}()
+
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&maxInFlight) == maxConcurrentVMLookups
+	}, time.Second, 10*time.Millisecond)
+
+	for range configured {
+		release <- struct{}{}
+	}
+
+	require.NoError(t, <-done)
+	assert.LessOrEqual(t, atomic.LoadInt32(&maxInFlight), int32(maxConcurrentVMLookups))
 }
 
 // Helper function to create time pointers

--- a/go/internal/usecase/list_vms_test.go
+++ b/go/internal/usecase/list_vms_test.go
@@ -19,6 +19,7 @@ var errTestList = errors.New("test error")
 func TestListVMsUseCase_Execute(t *testing.T) {
 	tests := []struct {
 		name        string
+		configured  []*model.VM
 		wantUptimes []string // Expected uptime strings for each VM
 		setupMock   func(*mock_repository.MockVMRepository)
 		wantLen     int
@@ -26,18 +27,19 @@ func TestListVMsUseCase_Execute(t *testing.T) {
 	}{
 		{
 			name: "single running VM with uptime",
+			configured: []*model.VM{
+				{Name: "test-vm", Project: "test-project", Zone: "us-central1-a"},
+			},
 			setupMock: func(m *mock_repository.MockVMRepository) {
-				vms := []*model.VM{
-					{
-						Name:          "test-vm",
-						Project:       "test-project",
-						Zone:          "us-central1-a",
-						MachineType:   "e2-medium",
-						Status:        model.StatusRunning,
-						LastStartTime: timePtr(time.Now().Add(-2 * time.Hour)),
-					},
+				vm := &model.VM{
+					Name:          "test-vm",
+					Project:       "test-project",
+					Zone:          "us-central1-a",
+					MachineType:   "e2-medium",
+					Status:        model.StatusRunning,
+					LastStartTime: timePtr(time.Now().Add(-2 * time.Hour)),
 				}
-				m.EXPECT().FindAll(gomock.Any()).Return(vms, nil)
+				m.EXPECT().FindByName(gomock.Any(), gomock.Any()).Return(vm, nil)
 			},
 			wantLen:     1,
 			wantUptimes: []string{"2h0m0s"}, // Approximately 2 hours
@@ -45,18 +47,19 @@ func TestListVMsUseCase_Execute(t *testing.T) {
 		},
 		{
 			name: "stopped VM returns N/A uptime",
+			configured: []*model.VM{
+				{Name: "stopped-vm", Project: "test-project", Zone: "us-central1-a"},
+			},
 			setupMock: func(m *mock_repository.MockVMRepository) {
-				vms := []*model.VM{
-					{
-						Name:          "stopped-vm",
-						Project:       "test-project",
-						Zone:          "us-central1-a",
-						MachineType:   "e2-medium",
-						Status:        model.StatusStopped,
-						LastStartTime: nil,
-					},
+				vm := &model.VM{
+					Name:          "stopped-vm",
+					Project:       "test-project",
+					Zone:          "us-central1-a",
+					MachineType:   "e2-medium",
+					Status:        model.StatusStopped,
+					LastStartTime: nil,
 				}
-				m.EXPECT().FindAll(gomock.Any()).Return(vms, nil)
+				m.EXPECT().FindByName(gomock.Any(), gomock.Any()).Return(vm, nil)
 			},
 			wantLen:     1,
 			wantUptimes: []string{"N/A"},
@@ -64,6 +67,10 @@ func TestListVMsUseCase_Execute(t *testing.T) {
 		},
 		{
 			name: "multiple VMs with mixed statuses",
+			configured: []*model.VM{
+				{Name: "running-vm", Project: "test-project", Zone: "us-central1-a"},
+				{Name: "stopped-vm", Project: "test-project", Zone: "us-west1-a"},
+			},
 			setupMock: func(m *mock_repository.MockVMRepository) {
 				vms := []*model.VM{
 					{
@@ -83,7 +90,19 @@ func TestListVMsUseCase_Execute(t *testing.T) {
 						LastStartTime: nil,
 					},
 				}
-				m.EXPECT().FindAll(gomock.Any()).Return(vms, nil)
+				m.EXPECT().
+					FindByName(gomock.Any(), gomock.Any()).
+					Times(2).
+					DoAndReturn(func(ctx context.Context, vm *model.VM) (*model.VM, error) {
+						switch vm.Name {
+						case "running-vm":
+							return vms[0], nil
+						case "stopped-vm":
+							return vms[1], nil
+						default:
+							return nil, errors.New("unexpected VM")
+						}
+					})
 			},
 			wantLen:     2,
 			wantUptimes: []string{"30m0s", "N/A"},
@@ -91,8 +110,11 @@ func TestListVMsUseCase_Execute(t *testing.T) {
 		},
 		{
 			name: "repository error",
+			configured: []*model.VM{
+				{Name: "error-vm", Project: "test-project", Zone: "us-central1-a"},
+			},
 			setupMock: func(m *mock_repository.MockVMRepository) {
-				m.EXPECT().FindAll(gomock.Any()).Return(nil, errTestList)
+				m.EXPECT().FindByName(gomock.Any(), gomock.Any()).Return(nil, errTestList)
 			},
 			wantLen:     0,
 			wantUptimes: nil,
@@ -111,7 +133,7 @@ func TestListVMsUseCase_Execute(t *testing.T) {
 			useCase := NewListVMsUseCase(mockRepo)
 			ctx := context.Background()
 
-			items, err := useCase.Execute(ctx)
+			items, err := useCase.Execute(ctx, tt.configured)
 
 			// Check error
 			if tt.wantError {

--- a/go/internal/usecase/update_machine_type.go
+++ b/go/internal/usecase/update_machine_type.go
@@ -62,7 +62,7 @@ func (uc *UpdateMachineTypeUseCase) Execute(ctx context.Context, project, zone, 
 	}
 
 	// 2. ビジネスルールチェック（VMは停止状態である必要がある）
-	if foundVM.CanStop() {
+	if !foundVM.CanChangeMachineType() {
 		return fmt.Errorf("VM %s must be stopped before changing machine type (current status: %s)", foundVM.Name, foundVM.Status)
 	}
 


### PR DESCRIPTION
## Description of the changes

この PR は、公開されている CLI コマンド体系を保ったまま、Go 実装内部の責務境界を整理します。

- `internal/interface/cli` に config 読み込みと設定済み VM 名の解決を集約し、Cobra command に重複していた parse/lookup 処理を削減しました。
- `VMRepository.FindAll` を削除し、設定ファイル由来の VM 一覧は caller/usecase 側で扱い、GCP repository は live state の取得に集中させました。
- `CanChangeMachineType()` を追加し、machine type 変更可否の業務ルールを `CanStop()` の流用ではなく明示的な名前で表しました。
- schedule policy 未設定時の `#NONE` 表示は presenter に寄せ、GCP infrastructure から表示都合の sentinel を外しました。
- GCP の schedule policy optional field を nil/empty-safe に扱うようにしました。
- `DescribeVM` を他の usecase と同じ `New...UseCase(...).Execute(...)` 形式に揃えました。
- `off` command の成功メッセージが `Turned on` になっていた不整合を修正しました。
- review feedback を受けて、`list` は 1 件の VM 取得失敗で全体を捨てず、取得できた VM を表示したうえで失敗分を集約 error として返す best-effort 動作にしました。
- `list` の並列 VM lookup に上限を設け、設定 VM 数が多い場合の GCP API/client 作成の burst を抑えました。

### なぜ修正したのか

- **SRP:** GCP repository が config file 読み込みまで担当すると、外部 API access と設定 source の責務が混ざります。repository は GCP の live state に集中させ、設定解決は CLI 境界へ寄せました。
- **DIP:** usecase が「ファイル由来の一覧取得」を repository interface に要求すると、repository の実装詳細が usecase 境界に漏れます。設定済み VM は caller が渡し、repository は `FindByName` で live state を返す形にしました。
- **DRY/KISS:** command ごとに config parse と VM lookup を繰り返す代わりに、小さい helper に集約しました。DI container や大きな抽象階層は入れていません。
- **Effective Go:** 業務ルールは読み手が意図を推測しなくてよい名前にしました。`CanChangeMachineType()` は `CanStop()` を「running 判定」として読むより明確です。
- **Robustness:** GCP API の optional field を直接 dereference せず、nil/empty を明示的に扱います。
- **User experience:** `list` は read-only な確認コマンドなので、1 件の失敗で他 VM の状態まで見えなくするより、取得できた結果を表示して失敗分を伝える方が実用的です。

## Issue ticket number and link

N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] Do we need to implement analytics? No.
- [x] Will this be part of a product update? No. ユーザー向けの機能追加ではなく、内部構造の整理とメッセージ修正です。

## Verification

- [x] `go test -v -race -tags=ci -shuffle=on ./...`
- [x] `golangci-lint run --config=./.golangci.yml ./...`
