### PR TITLE
refactor(go): CLIの設定解決処理を共通化

### DIFF
--- a/go/cmd/describe.go
+++ b/go/cmd/describe.go
@@ -9,9 +9,9 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/haru-256/gcectl/internal/infrastructure/config"
 	"github.com/haru-256/gcectl/internal/infrastructure/gcp"
 	infraLog "github.com/haru-256/gcectl/internal/infrastructure/log"
+	"github.com/haru-256/gcectl/internal/interface/cli"
 	"github.com/haru-256/gcectl/internal/interface/presenter"
 	"github.com/haru-256/gcectl/internal/usecase"
 	"github.com/spf13/cobra"
@@ -35,18 +35,9 @@ Example:
 			os.Exit(1)
 		}
 
-		// parse config
-		cnf, err := config.ParseConfig(CnfPath)
+		vm, err := cli.ResolveVMByName(CnfPath, vmName)
 		if err != nil {
-			console.Error(fmt.Sprintf("Failed to parse config: %v\n", err))
-			os.Exit(1)
-		}
-		infraLog.DefaultLogger.Debug(fmt.Sprintf("Config: %+v", cnf))
-
-		// filter VM by name
-		vm := cnf.GetVMByName(vmName)
-		if vm == nil {
-			console.Error(fmt.Sprintf("VM %s not found", vmName))
+			console.Error(fmt.Sprintf("%v\n", err))
 			os.Exit(1)
 		}
 

--- a/go/cmd/off.go
+++ b/go/cmd/off.go
@@ -8,10 +8,9 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/haru-256/gcectl/internal/domain/model"
-	"github.com/haru-256/gcectl/internal/infrastructure/config"
 	"github.com/haru-256/gcectl/internal/infrastructure/gcp"
 	infraLog "github.com/haru-256/gcectl/internal/infrastructure/log"
+	"github.com/haru-256/gcectl/internal/interface/cli"
 	"github.com/haru-256/gcectl/internal/interface/presenter"
 	"github.com/haru-256/gcectl/internal/usecase"
 	"github.com/spf13/cobra"
@@ -35,23 +34,10 @@ func offRun(cmd *cobra.Command, args []string) {
 	vmNames := args
 	infraLog.DefaultLogger.Debugf("Turning off the instances %s", strings.Join(vmNames, ", "))
 
-	// parse config
-	cnf, err := config.ParseConfig(CnfPath)
+	vms, err := cli.ResolveVMsByName(CnfPath, vmNames)
 	if err != nil {
-		console.Error(fmt.Sprintf("Failed to parse config: %v\n", err))
+		console.Error(fmt.Sprintf("%v\n", err))
 		os.Exit(1)
-	}
-	infraLog.DefaultLogger.Debug(fmt.Sprintf("Config: %+v", cnf))
-
-	// domain entity変換
-	var vms []*model.VM
-	for _, vmName := range vmNames {
-		vm := cnf.GetVMByName(vmName)
-		if vm == nil {
-			console.Error(fmt.Sprintf("VM %s not found", vmName))
-			os.Exit(1)
-		}
-		vms = append(vms, vm)
 	}
 
 	// 依存性の注入
@@ -72,7 +58,7 @@ func offRun(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	console.Success(fmt.Sprintf("Turned on the instances: %v\n", strings.Join(vmNames, ", ")))
+	console.Success(fmt.Sprintf("Turned off the instances: %v\n", strings.Join(vmNames, ", ")))
 }
 
 func init() {

--- a/go/cmd/on.go
+++ b/go/cmd/on.go
@@ -8,10 +8,9 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/haru-256/gcectl/internal/domain/model"
-	"github.com/haru-256/gcectl/internal/infrastructure/config"
 	"github.com/haru-256/gcectl/internal/infrastructure/gcp"
 	infraLog "github.com/haru-256/gcectl/internal/infrastructure/log"
+	"github.com/haru-256/gcectl/internal/interface/cli"
 	"github.com/haru-256/gcectl/internal/interface/presenter"
 	"github.com/haru-256/gcectl/internal/usecase"
 	"github.com/spf13/cobra"
@@ -35,23 +34,10 @@ func onRun(cmd *cobra.Command, args []string) {
 	vmNames := args
 	infraLog.DefaultLogger.Debugf("Turning on the instances %s", strings.Join(vmNames, ", "))
 
-	// parse config
-	cnf, err := config.ParseConfig(CnfPath)
+	vms, err := cli.ResolveVMsByName(CnfPath, vmNames)
 	if err != nil {
-		console.Error(fmt.Sprintf("Failed to parse config: %v\n", err))
+		console.Error(fmt.Sprintf("%v\n", err))
 		os.Exit(1)
-	}
-	infraLog.DefaultLogger.Debug(fmt.Sprintf("Config: %+v", cnf))
-
-	// domain entity変換
-	var vms []*model.VM
-	for _, vmName := range vmNames {
-		vm := cnf.GetVMByName(vmName)
-		if vm == nil {
-			console.Error(fmt.Sprintf("VM %s not found", vmName))
-			os.Exit(1)
-		}
-		vms = append(vms, vm)
 	}
 
 	// 依存性の注入

--- a/go/cmd/set/machine_type.go
+++ b/go/cmd/set/machine_type.go
@@ -7,9 +7,9 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/haru-256/gcectl/internal/infrastructure/config"
 	"github.com/haru-256/gcectl/internal/infrastructure/gcp"
 	infraLog "github.com/haru-256/gcectl/internal/infrastructure/log"
+	"github.com/haru-256/gcectl/internal/interface/cli"
 	"github.com/haru-256/gcectl/internal/interface/presenter"
 	"github.com/haru-256/gcectl/internal/usecase"
 	"github.com/spf13/cobra"
@@ -38,18 +38,9 @@ Example:
 			os.Exit(1)
 		}
 
-		// parse config
-		cnf, err := config.ParseConfig(cnfPath)
+		vm, err := cli.ResolveVMByName(cnfPath, vmName)
 		if err != nil {
-			console.Error(fmt.Sprintf("Failed to parse config: %v\n", err))
-			os.Exit(1)
-		}
-		infraLog.DefaultLogger.Debugf(fmt.Sprintf("Config: %+v", cnf))
-
-		// filter VM by name
-		vm := cnf.GetVMByName(vmName)
-		if vm == nil {
-			console.Error(fmt.Sprintf("VM %s not found", vmName))
+			console.Error(fmt.Sprintf("%v\n", err))
 			os.Exit(1)
 		}
 

--- a/go/cmd/set/schedule.go
+++ b/go/cmd/set/schedule.go
@@ -7,9 +7,9 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/haru-256/gcectl/internal/infrastructure/config"
 	"github.com/haru-256/gcectl/internal/infrastructure/gcp"
 	infraLog "github.com/haru-256/gcectl/internal/infrastructure/log"
+	"github.com/haru-256/gcectl/internal/interface/cli"
 	"github.com/haru-256/gcectl/internal/interface/presenter"
 	"github.com/haru-256/gcectl/internal/usecase"
 	"github.com/spf13/cobra"
@@ -38,18 +38,9 @@ Example:
 			os.Exit(1)
 		}
 
-		// parse config
-		cnf, err := config.ParseConfig(cnfPath)
+		vm, err := cli.ResolveVMByName(cnfPath, vmName)
 		if err != nil {
-			console.Error(fmt.Sprintf("Failed to parse config: %v\n", err))
-			os.Exit(1)
-		}
-		infraLog.DefaultLogger.Debugf(fmt.Sprintf("Config: %+v", cnf))
-
-		// filter VM by name
-		vm := cnf.GetVMByName(vmName)
-		if vm == nil {
-			console.Error(fmt.Sprintf("VM %s not found", vmName))
+			console.Error(fmt.Sprintf("%v\n", err))
 			os.Exit(1)
 		}
 

--- a/go/internal/interface/cli/config.go
+++ b/go/internal/interface/cli/config.go
@@ -11,7 +11,7 @@ import (
 func LoadConfig(configPath string) (*config.Config, error) {
 	cfg, err := config.ParseConfig(configPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse config: %w", err)
+		return nil, fmt.Errorf("failed to load config: %w", err)
 	}
 	return cfg, nil
 }

--- a/go/internal/interface/cli/config.go
+++ b/go/internal/interface/cli/config.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/haru-256/gcectl/internal/domain/model"
+	"github.com/haru-256/gcectl/internal/infrastructure/config"
+)
+
+// LoadConfig reads the gcectl configuration from disk.
+func LoadConfig(configPath string) (*config.Config, error) {
+	cfg, err := config.ParseConfig(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse config: %w", err)
+	}
+	return cfg, nil
+}
+
+// ResolveVMsByName loads configured VMs in the same order requested by name.
+func ResolveVMsByName(configPath string, names []string) ([]*model.VM, error) {
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	vms := make([]*model.VM, 0, len(names))
+	for _, name := range names {
+		vm := cfg.GetVMByName(name)
+		if vm == nil {
+			return nil, fmt.Errorf("VM %s not found", name)
+		}
+		vms = append(vms, vm)
+	}
+
+	return vms, nil
+}
+
+// ResolveVMByName loads one configured VM by name.
+func ResolveVMByName(configPath, name string) (*model.VM, error) {
+	vms, err := ResolveVMsByName(configPath, []string{name})
+	if err != nil {
+		return nil, err
+	}
+	return vms[0], nil
+}

--- a/go/internal/interface/cli/config_test.go
+++ b/go/internal/interface/cli/config_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfig(t *testing.T) {
+	configPath := writeConfig(t, `
+default-project: test-project
+default-zone: us-central1-a
+vm:
+  - name: test-vm
+`)
+
+	cfg, err := LoadConfig(configPath)
+
+	require.NoError(t, err)
+	require.Len(t, cfg.VMs, 1)
+	assert.Equal(t, "test-project", cfg.VMs[0].Project)
+	assert.Equal(t, "us-central1-a", cfg.VMs[0].Zone)
+}
+
+func TestResolveVMsByName(t *testing.T) {
+	configPath := writeConfig(t, `
+default-project: test-project
+default-zone: us-central1-a
+vm:
+  - name: vm-a
+  - name: vm-b
+    zone: asia-northeast1-a
+`)
+
+	vms, err := ResolveVMsByName(configPath, []string{"vm-b", "vm-a"})
+
+	require.NoError(t, err)
+	require.Len(t, vms, 2)
+	assert.Equal(t, "vm-b", vms[0].Name)
+	assert.Equal(t, "asia-northeast1-a", vms[0].Zone)
+	assert.Equal(t, "vm-a", vms[1].Name)
+	assert.Equal(t, "us-central1-a", vms[1].Zone)
+}
+
+func TestResolveVMsByNameReturnsMissingVM(t *testing.T) {
+	configPath := writeConfig(t, `
+default-project: test-project
+default-zone: us-central1-a
+vm:
+  - name: vm-a
+`)
+
+	vms, err := ResolveVMsByName(configPath, []string{"missing-vm"})
+
+	require.Error(t, err)
+	assert.Nil(t, vms)
+	assert.Contains(t, err.Error(), "VM missing-vm not found")
+}
+
+func writeConfig(t *testing.T, content string) string {
+	t.Helper()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(content), 0o600))
+	return configPath
+}

--- a/go/internal/interface/cli/config_test.go
+++ b/go/internal/interface/cli/config_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
-	configPath := writeConfig(t, `
-default-project: test-project
+	configPath := writeConfig(t, `default-project: test-project
 default-zone: us-central1-a
 vm:
   - name: test-vm
@@ -26,8 +25,7 @@ vm:
 }
 
 func TestResolveVMsByName(t *testing.T) {
-	configPath := writeConfig(t, `
-default-project: test-project
+	configPath := writeConfig(t, `default-project: test-project
 default-zone: us-central1-a
 vm:
   - name: vm-a
@@ -46,8 +44,7 @@ vm:
 }
 
 func TestResolveVMsByNameReturnsMissingVM(t *testing.T) {
-	configPath := writeConfig(t, `
-default-project: test-project
+	configPath := writeConfig(t, `default-project: test-project
 default-zone: us-central1-a
 vm:
   - name: vm-a


### PR DESCRIPTION
## Description of the changes

この PR は stacked refactor の 1 本目です。

- `internal/interface/cli` を追加し、config 読み込みと VM 名解決を共通化します。
- `on` / `off` / `describe` / `set machine-type` / `set schedule-policy` から重複していた config parse と VM lookup を削減します。
- `off` command の成功メッセージが `Turned on` になっていた不整合を修正します。

### なぜ修正したのか

- **DRY/KISS:** command ごとに同じ config parse と VM lookup を書くと、エラー処理やメッセージ修正が分散します。小さい helper に寄せることで、command は引数解釈と usecase 呼び出しに集中できます。
- **SRP:** CLI command の責務を「入力を受けて処理を呼ぶ」方向に寄せ、設定ファイルの解釈は helper に閉じ込めます。

## Stack

1. この PR: CLI の設定解決処理を共通化
2. `refactor/go-domain-usecases`: domain/usecase の語彙整理
3. `refactor/go-list-repository-boundary`: list と repository 境界の整理
4. `refactor/go-schedule-policy-formatting`: schedule policy 表示責務の整理

## Issue ticket number and link

N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] Do we need to implement analytics? No.
- [x] Will this be part of a product update? No. 内部リファクタリングです。

## Verification

- [x] `go test -tags=ci ./...`
