### PR TITLE
refactor(go): VM usecaseの業務ルールを明確化

### DIFF
--- a/go/cmd/describe.go
+++ b/go/cmd/describe.go
@@ -43,12 +43,13 @@ Example:
 
 		// 依存性の注入
 		vmRepo := gcp.NewVMRepository(CnfPath, infraLog.DefaultLogger)
+		describeVMUseCase := usecase.NewDescribeVMUseCase(vmRepo)
 
 		// Describe the instance
 		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
 
-		vmDetail, uptimeStr, err := usecase.DescribeVM(ctx, vmRepo, vm.Project, vm.Zone, vm.Name)
+		vmDetail, uptimeStr, err := describeVMUseCase.Execute(ctx, vm.Project, vm.Zone, vm.Name)
 		if err != nil {
 			console.Error(fmt.Sprintf("Failed to get VM info: %v\n", err))
 			os.Exit(1)

--- a/go/internal/domain/model/vm.go
+++ b/go/internal/domain/model/vm.go
@@ -137,6 +137,13 @@ func (v *VM) CanStop() bool {
 	return v.Status == StatusRunning
 }
 
+// CanChangeMachineType checks if the VM can have its machine type changed.
+//
+// GCE requires an instance to be stopped before changing its machine type.
+func (v *VM) CanChangeMachineType() bool {
+	return v.Status == StatusStopped || v.Status == StatusTerminated
+}
+
 var (
 	ErrVMNotRunning = errors.New("VM is not running")
 	ErrNoStartTime  = errors.New("VM start time is not available")

--- a/go/internal/domain/model/vm_test.go
+++ b/go/internal/domain/model/vm_test.go
@@ -179,6 +179,48 @@ func TestVM_CanStop(t *testing.T) {
 	}
 }
 
+func TestVM_CanChangeMachineType(t *testing.T) {
+	tests := []struct {
+		name   string
+		status Status
+		want   bool
+	}{
+		{
+			name:   "can change machine type when stopped",
+			status: StatusStopped,
+			want:   true,
+		},
+		{
+			name:   "can change machine type when terminated",
+			status: StatusTerminated,
+			want:   true,
+		},
+		{
+			name:   "cannot change machine type when running",
+			status: StatusRunning,
+			want:   false,
+		},
+		{
+			name:   "cannot change machine type when provisioning",
+			status: StatusProvisioning,
+			want:   false,
+		},
+		{
+			name:   "cannot change machine type when unknown",
+			status: StatusUnknown,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vm := &VM{Status: tt.status}
+			got := vm.CanChangeMachineType()
+			assert.Equal(t, tt.want, got, "VM.CanChangeMachineType() with status %v should return %v", tt.status, tt.want)
+		})
+	}
+}
+
 func TestVM_Uptime(t *testing.T) {
 	startTime := time.Date(2025, 10, 11, 10, 0, 0, 0, time.UTC)
 	now := time.Date(2025, 10, 11, 12, 30, 0, 0, time.UTC)

--- a/go/internal/usecase/describe_vm.go
+++ b/go/internal/usecase/describe_vm.go
@@ -2,13 +2,24 @@ package usecase
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/haru-256/gcectl/internal/domain/model"
 	"github.com/haru-256/gcectl/internal/domain/repository"
 )
 
-// DescribeVM retrieves detailed information about a specific VM and returns it with a calculated uptime string.
+// DescribeVMUseCase retrieves detailed information about a specific VM.
+type DescribeVMUseCase struct {
+	repo repository.VMRepository
+}
+
+// NewDescribeVMUseCase creates a new DescribeVMUseCase instance.
+func NewDescribeVMUseCase(repo repository.VMRepository) *DescribeVMUseCase {
+	return &DescribeVMUseCase{repo: repo}
+}
+
+// Execute retrieves detailed information about a specific VM and returns it with a calculated uptime string.
 //
 // This use case encapsulates the business logic of fetching a VM and calculating its uptime,
 // keeping this logic out of the presentation layer. The uptime is returned as a formatted string
@@ -16,7 +27,6 @@ import (
 //
 // Parameters:
 //   - ctx: Context for cancellation and timeout control
-//   - repo: VM repository interface for data access
 //   - project: GCP project ID
 //   - zone: GCP zone
 //   - name: VM instance name
@@ -28,21 +38,25 @@ import (
 //
 // Example:
 //
-//	vm, uptime, err := DescribeVM(ctx, repo, "my-project", "us-central1-a", "my-vm")
+//	useCase := NewDescribeVMUseCase(repo)
+//	vm, uptime, err := useCase.Execute(ctx, "my-project", "us-central1-a", "my-vm")
 //	if err != nil {
 //	    return err
 //	}
 //	// vm: &model.VM{Name: "my-vm", Status: model.StatusRunning, ...}
 //	// uptime: "2h30m15s"
-func DescribeVM(ctx context.Context, repo repository.VMRepository, project, zone, name string) (*model.VM, string, error) {
+func (u *DescribeVMUseCase) Execute(ctx context.Context, project, zone, name string) (*model.VM, string, error) {
 	vm := &model.VM{
 		Project: project,
 		Zone:    zone,
 		Name:    name,
 	}
-	foundVM, err := repo.FindByName(ctx, vm)
+	foundVM, err := u.repo.FindByName(ctx, vm)
 	if err != nil {
 		return nil, "", err
+	}
+	if foundVM == nil {
+		return nil, "", fmt.Errorf("VM %s: not found", name)
 	}
 
 	// Calculate uptime using shared logic

--- a/go/internal/usecase/describe_vm_test.go
+++ b/go/internal/usecase/describe_vm_test.go
@@ -114,6 +114,25 @@ func TestDescribeVM(t *testing.T) {
 			wantUptime: "",
 			wantErr:    true,
 		},
+		{
+			name:    "repository returns nil VM without error",
+			project: "test-project",
+			zone:    "us-central1-a",
+			vmName:  "missing-vm",
+			setupMock: func(m *mock_repository.MockVMRepository) {
+				expectedVM := &model.VM{
+					Name:    "missing-vm",
+					Project: "test-project",
+					Zone:    "us-central1-a",
+				}
+				m.EXPECT().
+					FindByName(gomock.Any(), gomock.Any()).
+					DoAndReturn(testhelpers.VMFindByNameMatcher(t, expectedVM, nil, nil))
+			},
+			wantVM:     nil,
+			wantUptime: "",
+			wantErr:    true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -124,7 +143,8 @@ func TestDescribeVM(t *testing.T) {
 			mockRepo := mock_repository.NewMockVMRepository(ctrl)
 			tt.setupMock(mockRepo)
 
-			vm, uptime, err := DescribeVM(context.Background(), mockRepo, tt.project, tt.zone, tt.vmName)
+			useCase := NewDescribeVMUseCase(mockRepo)
+			vm, uptime, err := useCase.Execute(context.Background(), tt.project, tt.zone, tt.vmName)
 
 			if tt.wantErr {
 				assert.Error(t, err, "DescribeVM() should return an error")

--- a/go/internal/usecase/update_machine_type.go
+++ b/go/internal/usecase/update_machine_type.go
@@ -60,6 +60,9 @@ func (uc *UpdateMachineTypeUseCase) Execute(ctx context.Context, project, zone, 
 	if err != nil {
 		return fmt.Errorf("failed to find VM: %w", err)
 	}
+	if foundVM == nil {
+		return fmt.Errorf("VM %s: not found", name)
+	}
 
 	// 2. ビジネスルールチェック（VMは停止状態である必要がある）
 	if !foundVM.CanChangeMachineType() {

--- a/go/internal/usecase/update_machine_type.go
+++ b/go/internal/usecase/update_machine_type.go
@@ -62,7 +62,7 @@ func (uc *UpdateMachineTypeUseCase) Execute(ctx context.Context, project, zone, 
 	}
 
 	// 2. ビジネスルールチェック（VMは停止状態である必要がある）
-	if foundVM.CanStop() {
+	if !foundVM.CanChangeMachineType() {
 		return fmt.Errorf("VM %s must be stopped before changing machine type (current status: %s)", foundVM.Name, foundVM.Status)
 	}
 

--- a/go/internal/usecase/update_machine_type_test.go
+++ b/go/internal/usecase/update_machine_type_test.go
@@ -100,6 +100,25 @@ func TestUpdateMachineTypeUseCase_Execute(t *testing.T) {
 			errContains: "failed to find VM",
 		},
 		{
+			name:        "error: repository returns nil VM without error",
+			project:     "test-project",
+			zone:        "us-central1-a",
+			vmName:      "missing-vm",
+			machineType: "e2-medium",
+			setupMock: func(m *mock_repository.MockVMRepository) {
+				expectedVM := &model.VM{
+					Name:    "missing-vm",
+					Project: "test-project",
+					Zone:    "us-central1-a",
+				}
+				m.EXPECT().
+					FindByName(gomock.Any(), gomock.Any()).
+					DoAndReturn(testhelpers.VMFindByNameMatcher(t, expectedVM, nil, nil))
+			},
+			wantErr:     true,
+			errContains: "not found",
+		},
+		{
 			name:        "error: VM is running",
 			project:     "test-project",
 			zone:        "us-central1-a",


### PR DESCRIPTION
## Description of the changes

この PR は stacked refactor の 2 本目です。base は `refactor/go-cli-config` です。

- `CanChangeMachineType()` を domain model に追加し、machine type 変更可否を明示的な名前で表します。
- `update_machine_type` usecase が `CanStop()` を別用途に流用していた箇所を置き換えます。
- `DescribeVM` を他 usecase と同じ `NewDescribeVMUseCase(...).Execute(...)` 形式へ揃えます。
- `FindByName` が nil VM / nil error を返した場合に panic せず `VM <name>: not found` を返します。
- 古い `DescribeVM` 関数形式の doc comment/example を更新します。

### なぜ修正したのか

- **Effective Go:** 読み手が意図を推測しなくてよい名前にします。`CanChangeMachineType()` は `CanStop()` を「running 判定」として読むより明確です。
- **SRP:** describe の usecase も他 usecase と同じ形に揃え、依存の持ち方を一貫させます。
- **Robustness:** repository mock/実装が nil を返すケースでも panic せず、明示的な error として扱います。

## Stack

1. #74: CLI の設定解決処理を共通化
2. この PR: domain/usecase の語彙整理
3. `refactor/go-list-repository-boundary`: list と repository 境界の整理
4. `refactor/go-schedule-policy-formatting`: schedule policy 表示責務の整理

## Issue ticket number and link

N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] Do we need to implement analytics? No.
- [x] Will this be part of a product update? No. 内部リファクタリングです。

## Verification

- [x] `go test -tags=ci ./...`
