### PR TITLE
refactor(go): list処理とGCP repositoryの境界を整理

### DIFF
--- a/go/cmd/describe.go
+++ b/go/cmd/describe.go
@@ -42,7 +42,7 @@ Example:
 		}
 
 		// 依存性の注入
-		vmRepo := gcp.NewVMRepository(CnfPath, infraLog.DefaultLogger)
+		vmRepo := gcp.NewVMRepository(infraLog.DefaultLogger)
 		describeVMUseCase := usecase.NewDescribeVMUseCase(vmRepo)
 
 		// Describe the instance

--- a/go/cmd/list.go
+++ b/go/cmd/list.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/haru-256/gcectl/internal/infrastructure/gcp"
 	infraLog "github.com/haru-256/gcectl/internal/infrastructure/log"
+	"github.com/haru-256/gcectl/internal/interface/cli"
 	"github.com/haru-256/gcectl/internal/interface/presenter"
 	"github.com/haru-256/gcectl/internal/usecase"
 	"github.com/spf13/cobra"
@@ -22,20 +23,21 @@ Example:
   gcectl list`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// 依存性の注入
-		vmRepo := gcp.NewVMRepository(CnfPath, infraLog.DefaultLogger)
 		console := presenter.NewConsolePresenter()
+		cfg, err := cli.LoadConfig(CnfPath)
+		if err != nil {
+			console.Error(fmt.Sprintf("%v\n", err))
+			os.Exit(1)
+		}
+
+		vmRepo := gcp.NewVMRepository(infraLog.DefaultLogger)
 		listVMsUC := usecase.NewListVMsUseCase(vmRepo)
 
 		// List VMs
 		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
 
-		items, err := listVMsUC.Execute(ctx)
-		if err != nil {
-			console.Error(fmt.Sprintf("Failed to list VMs: %v\n", err))
-			os.Exit(1)
-		}
-
+		items, err := listVMsUC.Execute(ctx, cfg.VMs)
 		infraLog.DefaultLogger.Debugf("Found %d VMs", len(items))
 
 		// Convert usecase items to presenter items
@@ -53,7 +55,13 @@ Example:
 		}
 
 		// Render VM list
-		console.RenderVMList(presenterItems)
+		if len(presenterItems) > 0 {
+			console.RenderVMList(presenterItems)
+		}
+		if err != nil {
+			console.Error(fmt.Sprintf("Failed to list some VMs: %v\n", err))
+			os.Exit(1)
+		}
 	},
 }
 

--- a/go/cmd/off.go
+++ b/go/cmd/off.go
@@ -41,7 +41,7 @@ func offRun(cmd *cobra.Command, args []string) {
 	}
 
 	// 依存性の注入
-	vmRepo := gcp.NewVMRepository(CnfPath, infraLog.DefaultLogger)
+	vmRepo := gcp.NewVMRepository(infraLog.DefaultLogger)
 	stopVMUseCase := usecase.NewStopVMUseCase(vmRepo, infraLog.DefaultLogger)
 
 	// Turn off the instances

--- a/go/cmd/on.go
+++ b/go/cmd/on.go
@@ -41,7 +41,7 @@ func onRun(cmd *cobra.Command, args []string) {
 	}
 
 	// 依存性の注入
-	vmRepo := gcp.NewVMRepository(CnfPath, infraLog.DefaultLogger)
+	vmRepo := gcp.NewVMRepository(infraLog.DefaultLogger)
 	startVMUseCase := usecase.NewStartVMUseCase(vmRepo, infraLog.DefaultLogger)
 
 	// Turn on the instances

--- a/go/cmd/set/machine_type.go
+++ b/go/cmd/set/machine_type.go
@@ -45,7 +45,7 @@ Example:
 		}
 
 		// 依存性の注入
-		vmRepo := gcp.NewVMRepository(cnfPath, infraLog.DefaultLogger)
+		vmRepo := gcp.NewVMRepository(infraLog.DefaultLogger)
 		updateMachineTypeUseCase := usecase.NewUpdateMachineTypeUseCase(vmRepo, infraLog.DefaultLogger)
 
 		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)

--- a/go/cmd/set/schedule.go
+++ b/go/cmd/set/schedule.go
@@ -45,7 +45,7 @@ Example:
 		}
 
 		// 依存性の注入
-		vmRepo := gcp.NewVMRepository(cnfPath, infraLog.DefaultLogger)
+		vmRepo := gcp.NewVMRepository(infraLog.DefaultLogger)
 
 		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 		defer stop()

--- a/go/internal/domain/repository/vm_repository.go
+++ b/go/internal/domain/repository/vm_repository.go
@@ -13,9 +13,6 @@ type VMRepository interface {
 	// FindByName retrieves a VM by its name, project, and zone
 	FindByName(ctx context.Context, vm *model.VM) (*model.VM, error)
 
-	// FindAll retrieves all VMs from the configuration
-	FindAll(ctx context.Context) ([]*model.VM, error)
-
 	// Start starts a VM instance
 	Start(ctx context.Context, vm *model.VM) error
 

--- a/go/internal/infrastructure/gcp/vm_repository_impl.go
+++ b/go/internal/infrastructure/gcp/vm_repository_impl.go
@@ -9,11 +9,9 @@ import (
 
 	compute "cloud.google.com/go/compute/apiv1"
 	"cloud.google.com/go/compute/apiv1/computepb"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/haru-256/gcectl/internal/domain/model"
 	"github.com/haru-256/gcectl/internal/domain/repository"
-	"github.com/haru-256/gcectl/internal/infrastructure/config"
 	"github.com/haru-256/gcectl/internal/infrastructure/log"
 )
 
@@ -21,35 +19,38 @@ import (
 //
 //nolint:govet // Field order optimized for readability over memory alignment
 type VMRepository struct {
-	configPath string
-	logger     log.Logger
+	logger log.Logger
 }
 
 // NewVMRepository creates a new VMRepository instance.
 //
 // Parameters:
-//   - configPath: Path to the configuration file
 //   - logger: Logger instance for logging
 //
 // Returns:
 //   - *VMRepository: A new repository instance
-func NewVMRepository(configPath string, logger log.Logger) *VMRepository {
+func NewVMRepository(logger log.Logger) *VMRepository {
 	return &VMRepository{
-		configPath: configPath,
-		logger:     logger,
+		logger: logger,
+	}
+}
+
+func (r *VMRepository) newInstancesClient(ctx context.Context) (*compute.InstancesClient, error) {
+	return compute.NewInstancesRESTClient(ctx)
+}
+
+func (r *VMRepository) closeInstancesClient(client *compute.InstancesClient) {
+	if closeErr := client.Close(); closeErr != nil {
+		r.logger.Errorf("Failed to close client: %v", closeErr)
 	}
 }
 
 func (r *VMRepository) FindByName(ctx context.Context, vm *model.VM) (*model.VM, error) {
-	client, err := compute.NewInstancesRESTClient(ctx)
+	client, err := r.newInstancesClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create client: %w", err)
 	}
-	defer func() {
-		if closeErr := client.Close(); closeErr != nil {
-			r.logger.Errorf("Failed to close client: %v", closeErr)
-		}
-	}()
+	defer r.closeInstancesClient(client)
 
 	req := &computepb.GetInstanceRequest{
 		Project:  vm.Project,
@@ -65,56 +66,12 @@ func (r *VMRepository) FindByName(ctx context.Context, vm *model.VM) (*model.VM,
 	return r.toModel(ctx, instance)
 }
 
-func (r *VMRepository) FindAll(ctx context.Context) ([]*model.VM, error) {
-	// 設定ファイルから VM リストを読み込み
-	cfg, err := config.ParseConfig(r.configPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load config: %w", err)
-	}
-
-	// errgroup を使用して並行実行
-	eg, ctx := errgroup.WithContext(ctx)
-	vmChan := make(chan *model.VM, len(cfg.VMs))
-
-	for _, cfgVM := range cfg.VMs {
-		cfgVM := cfgVM // ループ変数のキャプチャ
-		eg.Go(func() error {
-			vm, findErr := r.FindByName(ctx, cfgVM)
-			if findErr != nil {
-				// エラーをログに記録して続行
-				r.logger.Errorf("failed to find VM %s in project %s zone %s: %v", cfgVM.Name, cfgVM.Project, cfgVM.Zone, findErr)
-				return nil // エラーを返さずに続行
-			}
-			vmChan <- vm
-			return nil
-		})
-	}
-
-	// すべてのゴルーチンが完了するのを待つ
-	if waitErr := eg.Wait(); waitErr != nil {
-		return nil, fmt.Errorf("failed to fetch VMs: %w", waitErr)
-	}
-	close(vmChan)
-
-	// チャネルから結果を収集
-	vms := make([]*model.VM, 0, len(cfg.VMs))
-	for vm := range vmChan {
-		vms = append(vms, vm)
-	}
-
-	return vms, nil
-}
-
 func (r *VMRepository) Start(ctx context.Context, vm *model.VM) error {
-	client, err := compute.NewInstancesRESTClient(ctx)
+	client, err := r.newInstancesClient(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)
 	}
-	defer func() {
-		if closeErr := client.Close(); closeErr != nil {
-			r.logger.Errorf("Failed to close client: %v", closeErr)
-		}
-	}()
+	defer r.closeInstancesClient(client)
 
 	req := &computepb.StartInstanceRequest{
 		Project:  vm.Project,
@@ -131,15 +88,11 @@ func (r *VMRepository) Start(ctx context.Context, vm *model.VM) error {
 }
 
 func (r *VMRepository) Stop(ctx context.Context, vm *model.VM) error {
-	client, err := compute.NewInstancesRESTClient(ctx)
+	client, err := r.newInstancesClient(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)
 	}
-	defer func() {
-		if closeErr := client.Close(); closeErr != nil {
-			r.logger.Errorf("Failed to close client: %v", closeErr)
-		}
-	}()
+	defer r.closeInstancesClient(client)
 
 	req := &computepb.StopInstanceRequest{
 		Project:  vm.Project,
@@ -158,16 +111,12 @@ func (r *VMRepository) Stop(ctx context.Context, vm *model.VM) error {
 // SetSchedulePolicy attaches a schedule policy to a Google Compute Engine instance.
 func (r *VMRepository) SetSchedulePolicy(ctx context.Context, vm *model.VM, policyName string) error {
 	// Create a new InstancesClient with authentication
-	client, err := compute.NewInstancesRESTClient(ctx)
+	client, err := r.newInstancesClient(ctx)
 	if err != nil {
 		r.logger.Errorf("failed to create Instances client: %v", err)
 		return fmt.Errorf("failed to create client: %w", err)
 	}
-	defer func() {
-		if closeErr := client.Close(); closeErr != nil {
-			r.logger.Errorf("Failed to close client: %v", closeErr)
-		}
-	}()
+	defer r.closeInstancesClient(client)
 
 	// Get instance details
 	req := &computepb.GetInstanceRequest{
@@ -219,16 +168,12 @@ func (r *VMRepository) SetSchedulePolicy(ctx context.Context, vm *model.VM, poli
 // UnsetSchedulePolicy removes a schedule policy from a Google Compute Engine instance.
 func (r *VMRepository) UnsetSchedulePolicy(ctx context.Context, vm *model.VM, policyName string) error {
 	// Create a new InstancesClient with authentication
-	client, err := compute.NewInstancesRESTClient(ctx)
+	client, err := r.newInstancesClient(ctx)
 	if err != nil {
 		r.logger.Errorf("failed to create Instances client: %v", err)
 		return fmt.Errorf("failed to create client: %w", err)
 	}
-	defer func() {
-		if closeErr := client.Close(); closeErr != nil {
-			r.logger.Errorf("Failed to close client: %v", closeErr)
-		}
-	}()
+	defer r.closeInstancesClient(client)
 
 	// Get instance details
 	req := &computepb.GetInstanceRequest{
@@ -280,16 +225,12 @@ func (r *VMRepository) UnsetSchedulePolicy(ctx context.Context, vm *model.VM, po
 // UpdateMachineType changes the machine type of a VM instance.
 func (r *VMRepository) UpdateMachineType(ctx context.Context, vm *model.VM, machineType string) error {
 	// Create a new InstancesClient with authentication
-	client, err := compute.NewInstancesRESTClient(ctx)
+	client, err := r.newInstancesClient(ctx)
 	if err != nil {
 		r.logger.Errorf("failed to create Instances client: %v", err)
 		return fmt.Errorf("failed to create client: %w", err)
 	}
-	defer func() {
-		if closeErr := client.Close(); closeErr != nil {
-			r.logger.Errorf("Failed to close client: %v", closeErr)
-		}
-	}()
+	defer r.closeInstancesClient(client)
 
 	// Machine type must be in the format: zones/ZONE/machineTypes/MACHINE_TYPE
 	machineTypeURL := fmt.Sprintf("zones/%s/machineTypes/%s", vm.Zone, machineType)

--- a/go/internal/infrastructure/gcp/vm_repository_impl_test.go
+++ b/go/internal/infrastructure/gcp/vm_repository_impl_test.go
@@ -33,8 +33,8 @@ func getCnf(t *testing.T) (*config.Config, string) {
 }
 
 func TestVMRepositoryImpl_FindByName(t *testing.T) {
-	cnf, cnfPath := getCnf(t)
-	repo := gcp.NewVMRepository(cnfPath, logger)
+	cnf, _ := getCnf(t)
+	repo := gcp.NewVMRepository(logger)
 	ctx := context.Background()
 
 	tests := []struct {
@@ -82,39 +82,13 @@ func TestVMRepositoryImpl_FindByName(t *testing.T) {
 	}
 }
 
-func TestVMRepositoryImpl_FindAll(t *testing.T) {
-	cnf, cnfPath := getCnf(t)
-	repo := gcp.NewVMRepository(cnfPath, logger)
-	ctx := context.Background()
-
-	vms, err := repo.FindAll(ctx)
-	require.NoError(t, err)
-	require.NotNil(t, vms)
-	require.GreaterOrEqual(t, len(vms), len(cnf.VMs), "Should find at least the configured VMs")
-
-	// Verify that all configured VMs are found
-	for _, configVM := range cnf.VMs {
-		found := false
-		for _, vm := range vms {
-			if vm.Project == configVM.Project && vm.Zone == configVM.Zone && vm.Name == configVM.Name {
-				found = true
-				// Verify required fields are populated
-				assert.NotEmpty(t, vm.MachineType)
-				assert.NotEqual(t, model.StatusUnknown, vm.Status)
-				break
-			}
-		}
-		assert.True(t, found, "Configured VM %s/%s/%s should be found", configVM.Project, configVM.Zone, configVM.Name)
-	}
-}
-
 func TestVMRepositoryImpl_StartStop(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping long-running integration test in short mode")
 	}
 
-	cnf, cnfPath := getCnf(t)
-	repo := gcp.NewVMRepository(cnfPath, logger)
+	cnf, _ := getCnf(t)
+	repo := gcp.NewVMRepository(logger)
 	ctx := context.Background()
 
 	// Use the first configured VM for testing
@@ -194,8 +168,8 @@ func TestVMRepositoryImpl_UpdateMachineType(t *testing.T) {
 		t.Skip("Skipping long-running integration test in short mode")
 	}
 
-	cnf, cnfPath := getCnf(t)
-	repo := gcp.NewVMRepository(cnfPath, logger)
+	cnf, _ := getCnf(t)
+	repo := gcp.NewVMRepository(logger)
 	ctx := context.Background()
 
 	// Use the first configured VM for testing
@@ -274,8 +248,8 @@ func TestVMRepositoryImpl_SchedulePolicy(t *testing.T) {
 		t.Skip("Skipping long-running integration test in short mode")
 	}
 
-	cnf, cnfPath := getCnf(t)
-	repo := gcp.NewVMRepository(cnfPath, logger)
+	cnf, _ := getCnf(t)
+	repo := gcp.NewVMRepository(logger)
 	ctx := context.Background()
 
 	// Use the first configured VM for testing

--- a/go/internal/mock/repository/vm_repository_mock.go
+++ b/go/internal/mock/repository/vm_repository_mock.go
@@ -41,21 +41,6 @@ func (m *MockVMRepository) EXPECT() *MockVMRepositoryMockRecorder {
 	return m.recorder
 }
 
-// FindAll mocks base method.
-func (m *MockVMRepository) FindAll(ctx context.Context) ([]*model.VM, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindAll", ctx)
-	ret0, _ := ret[0].([]*model.VM)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FindAll indicates an expected call of FindAll.
-func (mr *MockVMRepositoryMockRecorder) FindAll(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAll", reflect.TypeOf((*MockVMRepository)(nil).FindAll), ctx)
-}
-
 // FindByName mocks base method.
 func (m *MockVMRepository) FindByName(ctx context.Context, vm *model.VM) (*model.VM, error) {
 	m.ctrl.T.Helper()

--- a/go/internal/usecase/list_vms.go
+++ b/go/internal/usecase/list_vms.go
@@ -80,13 +80,13 @@ func (u *ListVMsUseCase) Execute(ctx context.Context, configuredVMs []*model.VM)
 			vm, err := u.repo.FindByName(ctx, configuredVM)
 			if err != nil {
 				mu.Lock()
-				errs = append(errs, fmt.Errorf("failed to find VM %s: %w", configuredVM.Name, err))
+				errs = append(errs, fmt.Errorf("VM %s (project=%s, zone=%s): failed to find: %w", configuredVM.Name, configuredVM.Project, configuredVM.Zone, err))
 				mu.Unlock()
 				return nil
 			}
 			if vm == nil {
 				mu.Lock()
-				errs = append(errs, fmt.Errorf("VM %s: not found", configuredVM.Name))
+				errs = append(errs, fmt.Errorf("VM %s (project=%s, zone=%s): not found", configuredVM.Name, configuredVM.Project, configuredVM.Zone))
 				mu.Unlock()
 				return nil
 			}

--- a/go/internal/usecase/list_vms.go
+++ b/go/internal/usecase/list_vms.go
@@ -2,11 +2,17 @@ package usecase
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"sync"
 	"time"
 
 	"github.com/haru-256/gcectl/internal/domain/model"
 	"github.com/haru-256/gcectl/internal/domain/repository"
+	"golang.org/x/sync/errgroup"
 )
+
+const maxConcurrentVMLookups = 10
 
 // VMListItem represents a VM with its display information including uptime.
 // This struct is used to pass presentation-ready data from the use case layer
@@ -34,44 +40,75 @@ func NewListVMsUseCase(repo repository.VMRepository) *ListVMsUseCase {
 	}
 }
 
-// Execute retrieves all VMs and calculates their uptime strings.
+// Execute retrieves the configured VMs and calculates their uptime strings.
 //
 // This method encapsulates the business logic of calculating uptime,
-// which should not be in the presentation layer. For each VM, it:
-//   - Calls the shared calculateUptimeString() function
-//   - Returns "N/A" for VMs that are not running or have errors
+// which should not be in the presentation layer. VM lookups are best-effort:
+// successful lookups are returned, while failed lookups are collected into the
+// returned error so the caller can still render partial results.
 //
 // Parameters:
 //   - ctx: Context for cancellation and timeout control
+//   - configuredVMs: VMs loaded from config to query from the repository
 //
 // Returns:
-//   - []VMListItem: List of VMs with their calculated uptime strings
-//   - error: Error if VM retrieval fails
+//   - []VMListItem: Successfully retrieved VMs with calculated uptime strings
+//   - error: Joined error for failed VM lookups, or nil if all lookups succeed
 //
 // Example:
 //
 //	useCase := NewListVMsUseCase(repo)
-//	items, err := useCase.Execute(ctx)
+//	items, err := useCase.Execute(ctx, configuredVMs)
 //	if err != nil {
-//	    return err
+//	    fmt.Fprintf(os.Stderr, "some VMs could not be listed: %v\n", err)
 //	}
 //	for _, item := range items {
 //	    fmt.Printf("%s: %s\n", item.VM.Name, item.Uptime)
 //	}
-func (u *ListVMsUseCase) Execute(ctx context.Context) ([]VMListItem, error) {
-	vms, err := u.repo.FindAll(ctx)
-	if err != nil {
+func (u *ListVMsUseCase) Execute(ctx context.Context, configuredVMs []*model.VM) ([]VMListItem, error) {
+	now := time.Now()
+	items := make([]VMListItem, len(configuredVMs))
+	errs := make([]error, 0)
+	var mu sync.Mutex
+
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.SetLimit(maxConcurrentVMLookups)
+
+	for i, configuredVM := range configuredVMs {
+		i, configuredVM := i, configuredVM
+		eg.Go(func() error {
+			vm, err := u.repo.FindByName(ctx, configuredVM)
+			if err != nil {
+				mu.Lock()
+				errs = append(errs, fmt.Errorf("failed to find VM %s: %w", configuredVM.Name, err))
+				mu.Unlock()
+				return nil
+			}
+			if vm == nil {
+				mu.Lock()
+				errs = append(errs, fmt.Errorf("VM %s: not found", configuredVM.Name))
+				mu.Unlock()
+				return nil
+			}
+
+			items[i] = VMListItem{
+				VM:     vm,
+				Uptime: calculateUptimeString(vm, now),
+			}
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
 		return nil, err
 	}
 
-	now := time.Now()
-	items := make([]VMListItem, len(vms))
-	for i, vm := range vms {
-		items[i] = VMListItem{
-			VM:     vm,
-			Uptime: calculateUptimeString(vm, now),
+	successfulItems := make([]VMListItem, 0, len(items))
+	for _, item := range items {
+		if item.VM != nil {
+			successfulItems = append(successfulItems, item)
 		}
 	}
 
-	return items, nil
+	return successfulItems, errors.Join(errs...)
 }

--- a/go/internal/usecase/list_vms_test.go
+++ b/go/internal/usecase/list_vms_test.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -18,52 +19,59 @@ var errTestList = errors.New("test error")
 //nolint:gocognit // Test function is complex but readable with table-driven design
 func TestListVMsUseCase_Execute(t *testing.T) {
 	tests := []struct {
-		name        string
-		wantUptimes []string // Expected uptime strings for each VM
-		setupMock   func(*mock_repository.MockVMRepository)
-		wantLen     int
-		wantError   bool
+		name                string
+		configured          []*model.VM
+		wantUptimeAvailable []bool
+		setupMock           func(*mock_repository.MockVMRepository)
+		wantLen             int
+		wantError           bool
 	}{
 		{
 			name: "single running VM with uptime",
-			setupMock: func(m *mock_repository.MockVMRepository) {
-				vms := []*model.VM{
-					{
-						Name:          "test-vm",
-						Project:       "test-project",
-						Zone:          "us-central1-a",
-						MachineType:   "e2-medium",
-						Status:        model.StatusRunning,
-						LastStartTime: timePtr(time.Now().Add(-2 * time.Hour)),
-					},
-				}
-				m.EXPECT().FindAll(gomock.Any()).Return(vms, nil)
+			configured: []*model.VM{
+				{Name: "test-vm", Project: "test-project", Zone: "us-central1-a"},
 			},
-			wantLen:     1,
-			wantUptimes: []string{"2h0m0s"}, // Approximately 2 hours
-			wantError:   false,
+			setupMock: func(m *mock_repository.MockVMRepository) {
+				vm := &model.VM{
+					Name:          "test-vm",
+					Project:       "test-project",
+					Zone:          "us-central1-a",
+					MachineType:   "e2-medium",
+					Status:        model.StatusRunning,
+					LastStartTime: timePtr(time.Now().Add(-2 * time.Hour)),
+				}
+				m.EXPECT().FindByName(gomock.Any(), gomock.Any()).Return(vm, nil)
+			},
+			wantLen:             1,
+			wantUptimeAvailable: []bool{true},
+			wantError:           false,
 		},
 		{
 			name: "stopped VM returns N/A uptime",
-			setupMock: func(m *mock_repository.MockVMRepository) {
-				vms := []*model.VM{
-					{
-						Name:          "stopped-vm",
-						Project:       "test-project",
-						Zone:          "us-central1-a",
-						MachineType:   "e2-medium",
-						Status:        model.StatusStopped,
-						LastStartTime: nil,
-					},
-				}
-				m.EXPECT().FindAll(gomock.Any()).Return(vms, nil)
+			configured: []*model.VM{
+				{Name: "stopped-vm", Project: "test-project", Zone: "us-central1-a"},
 			},
-			wantLen:     1,
-			wantUptimes: []string{"N/A"},
-			wantError:   false,
+			setupMock: func(m *mock_repository.MockVMRepository) {
+				vm := &model.VM{
+					Name:          "stopped-vm",
+					Project:       "test-project",
+					Zone:          "us-central1-a",
+					MachineType:   "e2-medium",
+					Status:        model.StatusStopped,
+					LastStartTime: nil,
+				}
+				m.EXPECT().FindByName(gomock.Any(), gomock.Any()).Return(vm, nil)
+			},
+			wantLen:             1,
+			wantUptimeAvailable: []bool{false},
+			wantError:           false,
 		},
 		{
 			name: "multiple VMs with mixed statuses",
+			configured: []*model.VM{
+				{Name: "running-vm", Project: "test-project", Zone: "us-central1-a"},
+				{Name: "stopped-vm", Project: "test-project", Zone: "us-west1-a"},
+			},
 			setupMock: func(m *mock_repository.MockVMRepository) {
 				vms := []*model.VM{
 					{
@@ -83,20 +91,68 @@ func TestListVMsUseCase_Execute(t *testing.T) {
 						LastStartTime: nil,
 					},
 				}
-				m.EXPECT().FindAll(gomock.Any()).Return(vms, nil)
+				m.EXPECT().
+					FindByName(gomock.Any(), gomock.Any()).
+					Times(2).
+					DoAndReturn(func(ctx context.Context, vm *model.VM) (*model.VM, error) {
+						switch vm.Name {
+						case "running-vm":
+							return vms[0], nil
+						case "stopped-vm":
+							return vms[1], nil
+						default:
+							return nil, errors.New("unexpected VM")
+						}
+					})
 			},
-			wantLen:     2,
-			wantUptimes: []string{"30m0s", "N/A"},
-			wantError:   false,
+			wantLen:             2,
+			wantUptimeAvailable: []bool{true, false},
+			wantError:           false,
+		},
+		{
+			name: "partial results with repository error",
+			configured: []*model.VM{
+				{Name: "running-vm", Project: "test-project", Zone: "us-central1-a"},
+				{Name: "missing-vm", Project: "test-project", Zone: "us-west1-a"},
+			},
+			setupMock: func(m *mock_repository.MockVMRepository) {
+				runningVM := &model.VM{
+					Name:          "running-vm",
+					Project:       "test-project",
+					Zone:          "us-central1-a",
+					MachineType:   "e2-medium",
+					Status:        model.StatusRunning,
+					LastStartTime: timePtr(time.Now().Add(-30 * time.Minute)),
+				}
+				m.EXPECT().
+					FindByName(gomock.Any(), gomock.Any()).
+					Times(2).
+					DoAndReturn(func(ctx context.Context, vm *model.VM) (*model.VM, error) {
+						switch vm.Name {
+						case "running-vm":
+							return runningVM, nil
+						case "missing-vm":
+							return nil, errTestList
+						default:
+							return nil, errors.New("unexpected VM")
+						}
+					})
+			},
+			wantLen:             1,
+			wantUptimeAvailable: []bool{true},
+			wantError:           true,
 		},
 		{
 			name: "repository error",
-			setupMock: func(m *mock_repository.MockVMRepository) {
-				m.EXPECT().FindAll(gomock.Any()).Return(nil, errTestList)
+			configured: []*model.VM{
+				{Name: "error-vm", Project: "test-project", Zone: "us-central1-a"},
 			},
-			wantLen:     0,
-			wantUptimes: nil,
-			wantError:   true,
+			setupMock: func(m *mock_repository.MockVMRepository) {
+				m.EXPECT().FindByName(gomock.Any(), gomock.Any()).Return(nil, errTestList)
+			},
+			wantLen:             0,
+			wantUptimeAvailable: nil,
+			wantError:           true,
 		},
 	}
 
@@ -111,32 +167,79 @@ func TestListVMsUseCase_Execute(t *testing.T) {
 			useCase := NewListVMsUseCase(mockRepo)
 			ctx := context.Background()
 
-			items, err := useCase.Execute(ctx)
+			items, err := useCase.Execute(ctx, tt.configured)
 
-			// Check error
 			if tt.wantError {
 				assert.Error(t, err, "Execute() should return an error")
-				return
+			} else {
+				assert.NoError(t, err, "Execute() should not return an error")
 			}
 
-			assert.NoError(t, err, "Execute() should not return an error")
-
-			// Check length
 			require.Len(t, items, tt.wantLen, "Execute() should return %d items", tt.wantLen)
 
-			// Check uptime strings
 			for i, item := range items {
-				// For uptime, check if it's "N/A" or not
-				// Detailed format testing is covered in TestFormatUptime
-				if tt.wantUptimes[i] == "N/A" {
-					assert.Equal(t, "N/A", item.Uptime, "Execute() item[%d].Uptime should be N/A", i)
+				if tt.wantUptimeAvailable[i] {
+					assert.NotEqual(t, "N/A", item.Uptime, "Execute() item[%d].Uptime should contain uptime", i)
 				} else {
-					// For running VMs, just verify it's not "N/A"
-					assert.NotEqual(t, "N/A", item.Uptime, "Execute() item[%d].Uptime should not be N/A", i)
+					assert.Equal(t, "N/A", item.Uptime, "Execute() item[%d].Uptime should be N/A", i)
 				}
 			}
 		})
 	}
+}
+
+func TestListVMsUseCase_ExecuteLimitsConcurrentLookups(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	configured := make([]*model.VM, maxConcurrentVMLookups+1)
+	for i := range configured {
+		configured[i] = &model.VM{Name: "test-vm", Project: "test-project", Zone: "us-central1-a"}
+	}
+
+	var inFlight int32
+	var maxInFlight int32
+	release := make(chan struct{})
+	mockRepo := mock_repository.NewMockVMRepository(ctrl)
+	mockRepo.EXPECT().
+		FindByName(gomock.Any(), gomock.Any()).
+		Times(len(configured)).
+		DoAndReturn(func(ctx context.Context, vm *model.VM) (*model.VM, error) {
+			current := atomic.AddInt32(&inFlight, 1)
+			for {
+				previous := atomic.LoadInt32(&maxInFlight)
+				if current <= previous || atomic.CompareAndSwapInt32(&maxInFlight, previous, current) {
+					break
+				}
+			}
+			<-release
+			atomic.AddInt32(&inFlight, -1)
+			return &model.VM{
+				Name:          vm.Name,
+				Project:       vm.Project,
+				Zone:          vm.Zone,
+				MachineType:   "e2-medium",
+				Status:        model.StatusRunning,
+				LastStartTime: timePtr(time.Now().Add(-30 * time.Minute)),
+			}, nil
+		})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := NewListVMsUseCase(mockRepo).Execute(context.Background(), configured)
+		done <- err
+	}()
+
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&maxInFlight) == maxConcurrentVMLookups
+	}, time.Second, 10*time.Millisecond)
+
+	for range configured {
+		release <- struct{}{}
+	}
+
+	require.NoError(t, <-done)
+	assert.LessOrEqual(t, atomic.LoadInt32(&maxInFlight), int32(maxConcurrentVMLookups))
 }
 
 // Helper function to create time pointers


### PR DESCRIPTION
## Description of the changes

この PR は stacked refactor の 3 本目です。base は `refactor/go-domain-usecases` です。

- `VMRepository.FindAll` を削除し、GCP repository から config file 読み込み責務を外します。
- `ListVMsUseCase.Execute` は config 由来の VM 一覧を受け取り、各 VM の live state を `FindByName` で取得します。
- `list` は best-effort 動作にし、取得できた VM は表示しつつ、失敗した VM lookup は `errors.Join` で集約して返します。
- `errgroup.SetLimit` で VM lookup の並列数を制限し、GCP API/client 作成の burst を抑えます。
- `VMRepository` から未使用になった `configPath` dependency を削除します。

### なぜ修正したのか

- **SRP:** repository が config file の読み込みと GCP API access の両方を担当すると責務が混ざります。repository は live state 取得に集中させます。
- **DIP:** usecase が file-backed な一覧取得を repository interface に要求しない形にし、設定 source の詳細を外側に置きます。
- **User experience:** `list` は read-only な確認コマンドなので、1 件の VM が消えている/権限不足でも、取得できる VM の状態は表示できる方が実用的です。
- **KISS:** GCP client の長寿命化までは導入せず、まず call site の並列上限で過剰な burst を抑えます。

## Stack

1. #74: CLI の設定解決処理を共通化
2. #75: domain/usecase の語彙整理
3. この PR: list と repository 境界の整理
4. `refactor/go-schedule-policy-formatting`: schedule policy 表示責務の整理

## Issue ticket number and link

N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] Do we need to implement analytics? No.
- [x] Will this be part of a product update? No. 内部リファクタリングです。

## Verification

- [x] `go test -tags=ci ./...`
