### PR TITLE
fix(go): schedule policy表示責務をpresenterへ分離

### DIFF
--- a/go/internal/infrastructure/gcp/schedule_policy_test.go
+++ b/go/internal/infrastructure/gcp/schedule_policy_test.go
@@ -1,0 +1,65 @@
+package gcp
+
+import (
+	"testing"
+
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatInstanceSchedulePolicy(t *testing.T) {
+	tests := []struct {
+		name       string
+		policyName string
+		policy     *computepb.ResourcePolicyInstanceSchedulePolicy
+		want       string
+	}{
+		{
+			name:       "nil policy returns empty string",
+			policyName: "nightly-stop",
+			policy:     nil,
+			want:       "",
+		},
+		{
+			name:       "nil stop schedule returns policy name",
+			policyName: "nightly-stop",
+			policy:     &computepb.ResourcePolicyInstanceSchedulePolicy{},
+			want:       "nightly-stop",
+		},
+		{
+			name:       "nil schedule returns policy name",
+			policyName: "nightly-stop",
+			policy: &computepb.ResourcePolicyInstanceSchedulePolicy{
+				VmStopSchedule: &computepb.ResourcePolicyInstanceSchedulePolicySchedule{},
+			},
+			want: "nightly-stop",
+		},
+		{
+			name:       "empty schedule returns policy name",
+			policyName: "nightly-stop",
+			policy: &computepb.ResourcePolicyInstanceSchedulePolicy{
+				VmStopSchedule: &computepb.ResourcePolicyInstanceSchedulePolicySchedule{Schedule: stringPtr("")},
+			},
+			want: "nightly-stop",
+		},
+		{
+			name:       "schedule returns policy name with schedule",
+			policyName: "nightly-stop",
+			policy: &computepb.ResourcePolicyInstanceSchedulePolicy{
+				VmStopSchedule: &computepb.ResourcePolicyInstanceSchedulePolicySchedule{Schedule: stringPtr("0 22 * * *")},
+			},
+			want: "nightly-stop(0 22 * * *)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatInstanceSchedulePolicy(tt.policyName, tt.policy)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func stringPtr(v string) *string {
+	return &v
+}

--- a/go/internal/infrastructure/gcp/vm_repository_impl.go
+++ b/go/internal/infrastructure/gcp/vm_repository_impl.go
@@ -300,11 +300,9 @@ func (r *VMRepository) toModel(ctx context.Context, instance *computepb.Instance
 }
 
 func (r *VMRepository) getSchedulePolicy(ctx context.Context, instance *computepb.Instance) (string, error) {
-	defaultPolicy := "#NONE"
-
 	policies := instance.GetResourcePolicies()
 	if len(policies) == 0 {
-		return defaultPolicy, nil
+		return "", nil
 	}
 
 	policyClient, err := compute.NewResourcePoliciesRESTClient(ctx)
@@ -351,12 +349,26 @@ func (r *VMRepository) getSchedulePolicy(ctx context.Context, instance *computep
 		}
 
 		schedulePolicy := resourcePolicy.GetInstanceSchedulePolicy()
-		if schedulePolicy != nil {
-			return fmt.Sprintf("%s(%s)", policyName, *schedulePolicy.VmStopSchedule.Schedule), nil
+		if formattedPolicy := formatInstanceSchedulePolicy(policyName, schedulePolicy); formattedPolicy != "" {
+			return formattedPolicy, nil
 		}
 	}
 
-	return defaultPolicy, nil
+	return "", nil
+}
+
+func formatInstanceSchedulePolicy(policyName string, schedulePolicy *computepb.ResourcePolicyInstanceSchedulePolicy) string {
+	if schedulePolicy == nil {
+		return ""
+	}
+	if schedulePolicy.VmStopSchedule == nil || schedulePolicy.VmStopSchedule.Schedule == nil {
+		return policyName
+	}
+	schedule := schedulePolicy.VmStopSchedule.GetSchedule()
+	if schedule == "" {
+		return policyName
+	}
+	return fmt.Sprintf("%s(%s)", policyName, schedule)
 }
 
 func extractMachineType(fullURI string) string {

--- a/go/internal/infrastructure/gcp/vm_repository_impl.go
+++ b/go/internal/infrastructure/gcp/vm_repository_impl.go
@@ -361,7 +361,7 @@ func formatInstanceSchedulePolicy(policyName string, schedulePolicy *computepb.R
 	if schedulePolicy == nil {
 		return ""
 	}
-	if schedulePolicy.VmStopSchedule == nil || schedulePolicy.VmStopSchedule.Schedule == nil {
+	if schedulePolicy.VmStopSchedule == nil {
 		return policyName
 	}
 	schedule := schedulePolicy.VmStopSchedule.GetSchedule()

--- a/go/internal/interface/presenter/console.go
+++ b/go/internal/interface/presenter/console.go
@@ -123,7 +123,7 @@ func (p *ConsolePresenter) RenderVMList(items []VMListItem) {
 			item.Zone,
 			item.MachineType,
 			statusEmoji + " " + item.Status.String(),
-			item.SchedulePolicy,
+			formatSchedulePolicy(item.SchedulePolicy),
 			item.Uptime,
 		})
 	}
@@ -167,11 +167,18 @@ func (p *ConsolePresenter) RenderVMDetail(detail VMDetail) {
 		fmt.Sprintf("%s%s: %s", prefixStyle.Render(listItemsHeader[2]), itemPaddings[2], detail.Zone),
 		fmt.Sprintf("%s%s: %s", prefixStyle.Render(listItemsHeader[3]), itemPaddings[3], detail.MachineType),
 		fmt.Sprintf("%s%s: %s", prefixStyle.Render(listItemsHeader[4]), itemPaddings[4], detail.Status.String()),
-		fmt.Sprintf("%s%s: %s", prefixStyle.Render(listItemsHeader[5]), itemPaddings[5], detail.SchedulePolicy),
+		fmt.Sprintf("%s%s: %s", prefixStyle.Render(listItemsHeader[5]), itemPaddings[5], formatSchedulePolicy(detail.SchedulePolicy)),
 		fmt.Sprintf("%s%s: %s", prefixStyle.Render(listItemsHeader[6]), itemPaddings[6], detail.Uptime),
 	).Enumerator(list.Bullet).EnumeratorStyle(lipgloss.NewStyle().Padding(0, 1))
 
 	fmt.Println(l)
+}
+
+func formatSchedulePolicy(policy string) string {
+	if policy == "" {
+		return "#NONE"
+	}
+	return policy
 }
 
 // RenderVersion renders version information in a list format.

--- a/go/internal/interface/presenter/console_test.go
+++ b/go/internal/interface/presenter/console_test.go
@@ -327,6 +327,32 @@ func TestGetStatusEmoji(t *testing.T) {
 	}
 }
 
+func TestFormatSchedulePolicy(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy string
+		want   string
+	}{
+		{
+			name:   "empty policy displays none",
+			policy: "",
+			want:   "#NONE",
+		},
+		{
+			name:   "non-empty policy is unchanged",
+			policy: "nightly-stop(0 22 * * *)",
+			want:   "nightly-stop(0 22 * * *)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatSchedulePolicy(tt.policy)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestGetItemPaddings(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Description of the changes

この PR は stacked refactor の 4 本目です。base は `refactor/go-list-repository-boundary` です。

- schedule policy 未設定時の `#NONE` 表示を presenter 側へ移し、infrastructure から表示都合の sentinel を外します。
- GCP の schedule policy optional field を nil/empty-safe に扱います。
- empty schedule string は `policyName()` ではなく `policyName` と表示します。
- presenter と GCP formatter の unit test を追加します。

### なぜ修正したのか

- **SRP:** infrastructure は GCP API response を domain に近い値へ変換する責務に留め、CLI 表示用の sentinel は presenter に置きます。
- **Robustness:** GCP API の optional field を直接 dereference しないことで、nil pointer panic や `policyName()` のような紛らわしい表示を避けます。
- **KISS:** schedule policy 用の大きな value object は導入せず、現状の string 表現のまま表示責務だけを移しています。

## Stack

1. #74: CLI の設定解決処理を共通化
2. #75: domain/usecase の語彙整理
3. #76: list と repository 境界の整理
4. この PR: schedule policy 表示責務の整理

## Issue ticket number and link

N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] Do we need to implement analytics? No.
- [x] Will this be part of a product update? No. 内部リファクタリングです。

## Verification

- [x] `go test -tags=ci ./...`
- [x] `go test -v -race -tags=ci -shuffle=on ./...`（stack 全体のトップで実行）
- [x] `golangci-lint run --config=./.golangci.yml ./...`（stack 全体のトップで実行）
