### PR TITLE
chore(dependabot): group gomod minor and patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,13 @@ updates:
     directory: "go/"
     schedule:
       interval: "monthly"
+    groups:
+      minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
dependabot の gomod 更新をグループ化しました。

- minor/patch → 1 つの PR にまとめる
- major → 個別の PR で作成