### PR TITLE
chore(dependabot): group minor-patch updates only, leave major as individual PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,14 +31,16 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      major:
+      terraform-providers-major:
         patterns:
-          - "*"
+          - "hashicorp/google"
+          - "hashicorp/google-beta"
         update-types:
           - "major"
-      minor-patch:
+      terraform-providers-minor-patch:
         patterns:
-          - "*"
+          - "hashicorp/google"
+          - "hashicorp/google-beta"
         update-types:
           - "minor"
           - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,6 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      major:
-        patterns:
-          - "*"
-        update-types:
-          - "major"
       minor-patch:
         patterns:
           - "*"
@@ -22,11 +17,6 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      major:
-        patterns:
-          - "*"
-        update-types:
-          - "major"
       minor-patch:
         patterns:
           - "*"
@@ -43,12 +33,6 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      major:
-        patterns:
-          - "hashicorp/google"
-          - "hashicorp/google-beta"
-        update-types:
-          - "major"
       minor-patch:
         patterns:
           - "hashicorp/google"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,18 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "terraform"
     directories:
@@ -31,13 +43,13 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      terraform-providers-major:
+      major:
         patterns:
           - "hashicorp/google"
           - "hashicorp/google-beta"
         update-types:
           - "major"
-      terraform-providers-minor-patch:
+      minor-patch:
         patterns:
           - "hashicorp/google"
           - "hashicorp/google-beta"

--- a/docs/adr/0001-dependabot-update-grouping.md
+++ b/docs/adr/0001-dependabot-update-grouping.md
@@ -1,0 +1,35 @@
+# ADR-0001: Dependabot の更新 PR を minor/patch のみまとめる
+
+- Status: Accepted
+- Date: 2026-08-04
+
+## Context
+
+Dependabot は Go modules、GitHub Actions、Terraform の依存関係を月次で更新している。
+Terraform ではプロバイダが複数ディレクトリに存在するため、グループ化しないとモジュール × プロバイダごとに個別 PR が増える。
+一方で SemVer の major 更新は破壊的変更を含みやすく、まとめると原因切り分けが難しくなる。
+
+## Decision
+
+全エコシステム（gomod / github-actions / terraform）で次の方針とする。
+
+- **minor / patch**: 1 本の PR にまとめる
+- **major**: まとめず、依存ごとに個別 PR を出す
+
+設定は `.github/dependabot.yml` の `groups` に `minor-patch` のみを定義し、`major` グループは定義しないことで実現する。
+グループに含まれない major 更新は Dependabot が自動的に個別 PR として作成する。
+
+Terraform については、対象プロバイダ（`hashicorp/google` / `hashicorp/google-beta`）を明示し、複数ディレクトリを横断して minor/patch を 1 PR に集約する。
+
+## Consequences
+
+### Positive
+
+- minor / patch は挙動が変わらないことが多いため、まとめてレビュー・マージできる
+- major は CI が落ちることが予想されるため、個別 PR にして失敗原因を特定しやすい
+- Terraform のように同一プロバイダが複数ディレクトリに存在するケースでも、minor/patch の PR 数を抑えられる
+
+### Negative
+
+- major 更新が同時に複数ある場合は、個別 PR の数が増える
+- Terraform の major 更新はディレクトリごとに個別 PR になり得る

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,7 @@
+# Architecture Decision Records
+
+このディレクトリには、アーキテクチャや運用方針に関する意思決定を ADR として記録します。
+
+| ID | タイトル | ステータス |
+| --- | --- | --- |
+| [0001](0001-dependabot-update-grouping.md) | Dependabot の更新 PR を minor/patch のみまとめる | Accepted |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Dependabot の PR 戦略を全エコシステムで統一し、方針を ADR として記録しました。

- **minor / patch**: 1本の PR にまとめる
- **major**: まとめず、依存ごとに個別 PR

## 対象エコシステム

| エコシステム | minor-patch グループ | major |
|---|---|---|
| gomod | `patterns: ["*"]` | 個別 PR |
| github-actions | `patterns: ["*"]` | 個別 PR |
| terraform | `hashicorp/google`, `hashicorp/google-beta` | 個別 PR |

## ADR

方針の理由は [`docs/adr/0001-dependabot-update-grouping.md`](../blob/cursor/terraform-dependabot-grouping-d200/docs/adr/0001-dependabot-update-grouping.md) に記録しています。

- minor / patch は挙動が変わらないことが多いのでまとめてよい
- major は CI が落ちることが予想されるので個別 PR にする

## Test plan

- [x] Dependabot 設定バリデーションが通ること
- [ ] 次回スケジュール時に minor-patch がまとまった PR、major が個別 PR になることを確認
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fca69-3a16-7ba5-bd65-c5385d88d200?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fca69-3a16-7ba5-bd65-c5385d88d200&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

